### PR TITLE
:ambulance: :umbrella: Ignore events with "" prefix on linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/sync v0.1.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -154,6 +154,12 @@ func (w *Watcher) Run(ctx context.Context) error {
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				log.Debug().Str("path", event.Name).Msg("Adding path to watchlist")
 				err = watcher.Add(event.Name)
+				if err != nil {
+					log.Warn().Err(err).Str("path", event.Name).Msg("Could not add path to watcher")
+					if w.breakOnError {
+						return err
+					}
+				}
 			}
 
 			isWriteEvent := event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -64,12 +64,25 @@ func (w *Watcher) Run(ctx context.Context) error {
 			if !ok {
 				return nil
 			}
-			log.Debug().Str("event", event.String()).Msg("Received fsnotify event")
+			log.Debug().Str("op", event.Op.String()).
+				Str("name", event.Name).
+				Strs("watchList", watcher.WatchList()).
+				Msg("Received fsnotify event")
 
 			// if it is a deletion, remove the directory from the watcher
 			// TODO(manuel, 2023-03-27) There's a race condition here where a rename is a Create followed by a Remove.
 			// See also https://github.com/go-go-golems/cliopatra/issues/10
 			if event.Op&fsnotify.Remove == fsnotify.Remove {
+				err = removePathsWithPrefix(watcher, event.Name)
+				if err != nil {
+					log.Warn().Err(err).Str("path", event.Name).Msg("Could not remove path from watcher")
+					if w.breakOnError {
+						return err
+					}
+				}
+			}
+
+			if event.Op&fsnotify.Rename == fsnotify.Rename {
 				err = removePathsWithPrefix(watcher, event.Name)
 				if err != nil {
 					log.Warn().Err(err).Str("path", event.Name).Msg("Could not remove path from watcher")
@@ -87,6 +100,9 @@ func (w *Watcher) Run(ctx context.Context) error {
 					log.Debug().Err(err).Str("path", event.Name).Msg("Could not stat path")
 					continue
 				}
+
+				// if a directory was created, we always add it. For files, we must first check if it matches
+				// the globs.
 				if info.IsDir() {
 					log.Debug().Str("path", event.Name).Msg("Adding new directory to watcher")
 					err = addRecursive(watcher, event.Name)
@@ -100,6 +116,7 @@ func (w *Watcher) Run(ctx context.Context) error {
 				}
 			}
 
+			// check if the path matches the globs
 			if len(w.masks) > 0 {
 				matched := false
 				for _, mask := range w.masks {
@@ -125,10 +142,18 @@ func (w *Watcher) Run(ctx context.Context) error {
 				}
 			}
 
+			if event.Name == "" {
+				// This is a workaround for a bug in fsnotify where the name is empty.
+				// This might be a race condition with removing the renamed file and adding it again.
+				// The Rename event is triggered by MOVE_FROM. Ignoring the empty path seems to work fine,
+				// the Rename on the proper path is triggered afterwards.
+				continue
+			}
+
+			// if the new file is valid, add it to the watcher for changes and removal
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				log.Debug().Str("path", event.Name).Msg("Adding path to watchlist")
 				err = watcher.Add(event.Name)
-				log.Debug().Err(err).Strs("watchlist", watcher.WatchList()).Msg("Watchlist")
 			}
 
 			isWriteEvent := event.Op&fsnotify.Write == fsnotify.Write || event.Op&fsnotify.Create == fsnotify.Create
@@ -213,6 +238,12 @@ func NewWatcher(options ...Option) *Watcher {
 
 // removePathsWithPrefix removes `name` and all subdirectories from the watcher
 func removePathsWithPrefix(watcher *fsnotify.Watcher, name string) error {
+	// if the path is "", which happens on linux because we are still watching individual files there,
+	// ignore, because we would otherwise remove all the watched prefixes.
+	if name == "" {
+		log.Debug().Msg("Ignoring empty prefixes")
+		return nil
+	}
 	// we do the "recursion" by checking the watchlist of the watcher for all watched directories
 	// that has name as prefix
 	watchlist := watcher.WatchList()

--- a/pkg/watcher/watcher_test.go
+++ b/pkg/watcher/watcher_test.go
@@ -1,0 +1,112 @@
+package watcher
+
+import (
+	"context"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sync/errgroup"
+	"os"
+	"testing"
+	"time"
+)
+
+var tempDir string
+
+func TestMain(m *testing.M) {
+	// set logging level to debug
+	log.Level(zerolog.DebugLevel)
+
+	// create a temporary directory.
+	dir, err := os.MkdirTemp("", "clay")
+	if err != nil {
+		panic(err)
+	}
+	tempDir = dir
+	defer func(path string) {
+		err := os.RemoveAll(path)
+		if err != nil {
+			panic(err)
+		}
+	}(dir) // clean up
+
+	m.Run()
+}
+
+func TestSimpleFileAddition(t *testing.T) {
+	addedCh := make(chan string)
+
+	w := NewWatcher(WithPaths(tempDir), WithWriteCallback(func(path string) error {
+		log.Debug().Str("path", path).Msg("received path")
+		addedCh <- path
+		return nil
+	}))
+
+	expectedPath := tempDir + "/test.txt"
+
+	eg, ctx := errgroup.WithContext(context.Background())
+	ctx2, cancel := context.WithCancel(ctx)
+
+	eg.Go(func() error {
+		log.Debug().Msg("starting watcher")
+		err := w.Run(ctx2)
+		log.Debug().Msg("watcher stopped")
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+
+	eg.Go(func() error {
+		defer cancel()
+
+		log.Debug().Msg("waiting for file to be added")
+
+		// wait for 2 seconds before failing, in case nothing happens
+		timer := time.NewTimer(2 * time.Second)
+		defer timer.Stop()
+
+		log.Debug().Msg("waiting for file to be added")
+
+		select {
+		case <-timer.C:
+			log.Debug().Msg("timed out waiting for file to be added")
+			assert.Fail(t, "timed out waiting for file to be added")
+			return errors.New("timed out waiting for file to be added")
+		case path := <-addedCh:
+			log.Debug().Msgf("received path %s", path)
+			assert.Equal(t, expectedPath, path)
+			if path != expectedPath {
+				return errors.New("received path does not match expected path")
+			}
+			return nil
+		case <-ctx2.Done():
+			return nil
+		}
+	})
+
+	eg.Go(func() error {
+		// wait for 500 ms before creating file, to have the watcher settle
+		timer := time.NewTimer(500 * time.Millisecond)
+		defer timer.Stop()
+		select {
+		case <-timer.C:
+			log.Debug().Msgf("creating file %s", expectedPath)
+			f, err := os.Create(expectedPath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			return nil
+		case <-ctx2.Done():
+			return nil
+		}
+	})
+
+	err := eg.Wait()
+	if err == context.Canceled {
+		return
+	}
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
There seems to be a slight race condition with the way the events are handled on renaming,
even though I couldn't really figure it out from the fsnotify_inotify code used on linux.

For now, ignoring events with an empty prefix (meaning their original file got moved) seems
to work fine.

- :umbrella: Add unit test for watcher file creation
- :art: Refactor test to have a nice easy API
- :umbrella: Add many more tests that also check the triple rename bug
- :ambulance: Fix watching renames that seem to trigger empty prefix events
