### PR TITLE
Add RenderQuery helper function to SQL package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/go-go-golems/glazed v0.4.29
+	github.com/go-go-golems/glazed v0.4.30
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/glazed v0.4.29 h1:JJkvQgGjN/E9KCturwnNBtWp79RoQ8o2rIeIVTIqehw=
-github.com/go-go-golems/glazed v0.4.29/go.mod h1:2S8zYdqfC0eWTPicL1ot/I7sDG+hC+ach6atPXYnGEc=
+github.com/go-go-golems/glazed v0.4.30 h1:cDYcjbLcu3wkCBfYPMtvrBLuRYU3aSYcxpKAV2mT3MM=
+github.com/go-go-golems/glazed v0.4.30/go.mod h1:2S8zYdqfC0eWTPicL1ot/I7sDG+hC+ach6atPXYnGEc=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/sql/template.go
+++ b/pkg/sql/template.go
@@ -88,6 +88,9 @@ func sqlLike(value string) string {
 	return "'%" + value + "%'"
 }
 
+// TODO(manuel, 2023-11-19) Wrap this in a templating class that can accept additional funcmaps
+// (and maybe more templating functionality)
+
 func CreateTemplate(
 	ctx context.Context,
 	subQueries map[string]string,


### PR DESCRIPTION
- Adds `RenderQuery` function for processing and rendering SQL query templates.
- Enhances `CreateTemplate` with new functionality to support extended templating.