### PR TITLE
Enhance date and datetime parsing with timezone support

### DIFF
--- a/pkg/sql/template.go
+++ b/pkg/sql/template.go
@@ -61,9 +61,16 @@ func sqlDate(date interface{}) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "'" + parsedDate.Format("2006-01-02") + "'", nil
+		// if timezone is local, output YYYY-mm-dd
+		if parsedDate.Location() == time.Local {
+			return "'" + parsedDate.Format("2006-01-02") + "'", nil
+		}
+		return "'" + parsedDate.Format(time.RFC3339) + "'", nil
 	case time.Time:
-		return "'" + v.Format("2006-01-02") + "'", nil
+		if v.Location() == time.Local {
+			return "'" + v.Format("2006-01-02") + "'", nil
+		}
+		return "'" + v.Format(time.RFC3339) + "'", nil
 	default:
 		return "", fmt.Errorf("could not parse date %v", date)
 	}
@@ -76,9 +83,15 @@ func sqlDateTime(date interface{}) (string, error) {
 		if err != nil {
 			return "", err
 		}
-		return "'" + parsedDate.Format("2006-01-02 15:03:04") + "'", nil
+		if parsedDate.Location() == time.Local {
+			return "'" + parsedDate.Format("2006-01-02T15:04:05") + "'", nil
+		}
+		return "'" + parsedDate.Format(time.RFC3339) + "'", nil
 	case time.Time:
-		return "'" + v.Format("2006-01-02 15:02:03") + "'", nil
+		if v.Location() == time.Local {
+			return "'" + v.Format("2006-01-02T15:04:05") + "'", nil
+		}
+		return "'" + v.Format(time.RFC3339) + "'", nil
 	default:
 		return "", fmt.Errorf("could not parse date %v", date)
 	}

--- a/pkg/sql/template_test.go
+++ b/pkg/sql/template_test.go
@@ -1,0 +1,126 @@
+package sql
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestSqlDate(t *testing.T) {
+	locationNewYork, _ := time.LoadLocation("America/New_York")
+	locationTokyo, _ := time.LoadLocation("Asia/Tokyo")
+
+	tests := []struct {
+		name     string
+		input    time.Time
+		expected string
+	}{
+		{
+			name:     "Standard date (local)",
+			input:    time.Date(2023, 3, 14, 0, 0, 0, 0, time.Local),
+			expected: "'2023-03-14'",
+		},
+		{
+			name:     "Leap year date UTC",
+			input:    time.Date(2020, 2, 29, 0, 0, 0, 0, time.UTC),
+			expected: "'2020-02-29T00:00:00Z'",
+		},
+		{
+			name:     "Date with time zone New York",
+			input:    time.Date(2023, 3, 14, 0, 0, 0, 0, locationNewYork),
+			expected: "'2023-03-14T00:00:00-04:00'",
+		},
+		{
+			name:     "Date with time zone Tokyo",
+			input:    time.Date(2023, 3, 14, 0, 0, 0, 0, locationTokyo),
+			expected: "'2023-03-14T00:00:00+09:00'",
+		},
+		{
+			name:  "Unix epoch",
+			input: time.Unix(0, 0),
+			expected: func() string {
+				// compute unix time 1970-01-01 in time.Local
+				t := time.Unix(0, 0)
+				return "'" + t.Format("2006-01-02") + "'"
+			}(),
+		},
+		{
+			name:     "Date before Unix epoch",
+			input:    time.Date(1969, 12, 31, 0, 0, 0, 0, time.UTC),
+			expected: "'1969-12-31T00:00:00Z'",
+		},
+		// Add more test cases if needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sqlDate(tt.input)
+			if err != nil {
+				t.Errorf("sqlDate(%v) returned an error: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("sqlDate(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSqlDateTime(t *testing.T) {
+	locationNewYork, _ := time.LoadLocation("America/New_York")
+	locationTokyo, _ := time.LoadLocation("Asia/Tokyo")
+
+	tests := []struct {
+		name     string
+		input    time.Time
+		expected string
+	}{
+		{
+			name:     "Standard datetime (local)",
+			input:    time.Date(2023, 3, 14, 21, 36, 45, 0, time.Local),
+			expected: "'2023-03-14T21:36:45'",
+		},
+		{
+			name:     "Standard datetime UTC",
+			input:    time.Date(2023, 3, 14, 21, 36, 45, 0, time.UTC),
+			expected: "'2023-03-14T21:36:45Z'",
+		},
+		{
+			name:     "Datetime with nanoseconds UTC",
+			input:    time.Date(2023, 3, 14, 21, 36, 45, 123456789, time.UTC),
+			expected: "'2023-03-14T21:36:45Z'",
+		},
+		{
+			name:     "Datetime with time zone New York",
+			input:    time.Date(2023, 3, 14, 21, 36, 45, 0, locationNewYork),
+			expected: fmt.Sprintf("'%s'", time.Date(2023, 3, 14, 21, 36, 45, 0, locationNewYork).Format(time.RFC3339)),
+		},
+		{
+			name:     "Datetime with time zone Tokyo",
+			input:    time.Date(2023, 3, 14, 21, 36, 45, 0, locationTokyo),
+			expected: fmt.Sprintf("'%s'", time.Date(2023, 3, 14, 21, 36, 45, 0, locationTokyo).Format(time.RFC3339)),
+		},
+		{
+			name:     "Unix epoch with time",
+			input:    time.Unix(0, 0).Add(8*time.Hour + 30*time.Minute),
+			expected: "'1970-01-01T03:30:00'",
+		},
+		{
+			name:     "Datetime before Unix epoch",
+			input:    time.Date(1969, 12, 31, 23, 59, 59, 0, time.UTC),
+			expected: "'1969-12-31T23:59:59Z'",
+		},
+		// Add more test cases if needed
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := sqlDateTime(tt.input)
+			if err != nil {
+				t.Errorf("sqlDateTime(%v) returned an error: %v", tt.input, err)
+			}
+			if result != tt.expected {
+				t.Errorf("sqlDateTime(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces improvements to the `parseDate` and `parseDateTime`
functions within the SQL package to correctly handle dates and datetimes with
timezone information. The changes ensure that the output is consistent with the
input's timezone, defaulting to local time or RFC3339 format as appropriate.

Key changes include:
- Adjusting the `sqlDate` and `sqlDateTime` functions to return dates and
  datetimes in the local timezone without any timezone offset if the input
  timezone is local.
- Modifying the same functions to return dates and datetimes in RFC3339 format
  with the timezone offset when the input timezone is not local.
- Adding comprehensive test cases in `template_test.go` to validate the new
  behavior for various scenarios, including standard dates, leap years, dates
  with different timezones, and dates before the Unix epoch.

These enhancements ensure that our SQL package can handle a wider range of
date and datetime inputs, providing more accurate and expected outputs for
SQL queries involving date and time operations.