### PR TITLE
Unify command loader interfaces across the project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/go-go-golems/glazed v0.4.34
+	github.com/go-go-golems/glazed v0.4.35
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.9

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/glazed v0.4.34 h1:QEvfpYoRHiLBMnHkqVrZJs9+e1rHWKPTPu1PTbYWu1c=
-github.com/go-go-golems/glazed v0.4.34/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
+github.com/go-go-golems/glazed v0.4.35 h1:ndRHgBgOqp6VuBVzKHiT/mtN/eZ+9bz9q1C8UPM8l0g=
+github.com/go-go-golems/glazed v0.4.35/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=
 github.com/go-openapi/errors v0.20.3/go.mod h1:Z3FlZ4I8jEGxjUK+bugx3on2mIAk4txuAOhlsB1FSgk=
 github.com/go-openapi/strfmt v0.21.7 h1:rspiXgNWgeUzhjo1YU01do6qsahtJNByjLVbPLNHb8k=

--- a/pkg/cmds/locations.go
+++ b/pkg/cmds/locations.go
@@ -106,7 +106,7 @@ func NewCommandLoader[T glazed_cmds.Command](locations *CommandLocations) *Comma
 }
 
 func (c *CommandLoader[T]) LoadCommands(
-	loader loaders.FSCommandLoader,
+	loader loaders.CommandLoader,
 	helpSystem *help.HelpSystem,
 	options ...glazed_cmds.CommandDescriptionOption,
 ) ([]T, []*alias.CommandAlias, error) {
@@ -150,7 +150,7 @@ func (c *CommandLoader[T]) LoadCommands(
 }
 
 func (c *CommandLoader[T]) loadEmbeddedCommands(
-	loader loaders.FSCommandLoader,
+	loader loaders.CommandLoader,
 	helpSystem *help.HelpSystem,
 	options ...glazed_cmds.CommandDescriptionOption,
 ) ([]T, []*alias.CommandAlias, error) {
@@ -166,7 +166,7 @@ func (c *CommandLoader[T]) loadEmbeddedCommands(
 			alias.WithPrependSource("embed:" + e.Name + ":"),
 			alias.WithStripParentsPrefix([]string{e.Root}),
 		}
-		commands_, err := loader.LoadCommandsFromFS(e.FS, e.Root, options_, aliasOptions)
+		commands_, err := loaders.LoadCommandsFromFS(e.FS, e.Root, loader, options_, aliasOptions)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -196,7 +196,7 @@ func (c *CommandLoader[T]) loadEmbeddedCommands(
 }
 
 func (c *CommandLoader[T]) loadRepositoryCommands(
-	loader loaders.FSCommandLoader,
+	loader loaders.CommandLoader,
 	helpSystem *help.HelpSystem,
 	options ...glazed_cmds.CommandDescriptionOption,
 ) ([]T, []*alias.CommandAlias, error) {
@@ -227,9 +227,10 @@ func (c *CommandLoader[T]) loadRepositoryCommands(
 			aliasOptions := []alias.Option{
 				alias.WithPrependSource(repository + "/"),
 			}
-			commands_, err := loader.LoadCommandsFromFS(
+			commands_, err := loaders.LoadCommandsFromFS(
 				os.DirFS(repository),
 				".",
+				loader,
 				options_,
 				aliasOptions,
 			)

--- a/pkg/repositories/fs/helpers.go
+++ b/pkg/repositories/fs/helpers.go
@@ -36,12 +36,14 @@ func LoadCommandsFromInputs(
 		return nil, err
 	}
 
-	// create normal fs.FS
-	f := os.DirFS("/")
-
 	commands := repository.CollectCommands([]string{}, true)
 	for _, file := range files {
-		cmds_, err := commandLoader.LoadCommands(f, file, []cmds.CommandDescriptionOption{}, []alias.Option{})
+		f, file_, err := loaders.FileNameToFsFilePath(file)
+		if err != nil {
+			return nil, err
+		}
+
+		cmds_, err := commandLoader.LoadCommands(f, file_, []cmds.CommandDescriptionOption{}, []alias.Option{})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/repositories/fs/repository.go
+++ b/pkg/repositories/fs/repository.go
@@ -25,9 +25,7 @@ type Repository struct {
 	removeCallback RemoveCallback
 
 	// fsLoader is used to load all commands on startup
-	fsLoader loaders.FSCommandLoader
-	// readerLoader is used to reload a single command from a single file that changed while watching
-	readerLoader loaders.ReaderCommandLoader
+	fsLoader loaders.CommandLoader
 	// these options are passed to the loader to create new descriptions
 	cmdOptions []cmds.CommandDescriptionOption
 }
@@ -49,17 +47,9 @@ func WithDirectories(directories []string) RepositoryOption {
 	}
 }
 
-// WithReaderCommandLoader sets the command loader to use when loading commands from
-// an updated file when it changes.
-func WithReaderCommandLoader(loader loaders.ReaderCommandLoader) RepositoryOption {
-	return func(r *Repository) {
-		r.readerLoader = loader
-	}
-}
-
 // WithFSLoader sets the command loader to use when loading commands from
 // the filesystem on startup or when a directory changes.
-func WithFSLoader(loader loaders.FSCommandLoader) RepositoryOption {
+func WithFSLoader(loader loaders.CommandLoader) RepositoryOption {
 	return func(r *Repository) {
 		r.fsLoader = loader
 	}


### PR DESCRIPTION
This pull request refactors the command loader interfaces to provide a
consistent and unified approach throughout the project:

- Replaced various loader interfaces with a single `CommandLoader` interface.
- Modified method signatures to align with the new interface, enhancing
  consistency.
- Simplified command loading logic by removing redundant interfaces and
  streamlining the process.
- Updated the `Repository` and `Watcher` components to utilize the new
  unified loader, improving code clarity and maintainability.