### PR TITLE
Refactor directory and alias handling in repositories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.19
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/go-go-golems/glazed v0.5.7
+	github.com/go-go-golems/glazed v0.5.8
 	github.com/go-go-golems/sqleton v0.2.4
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbS
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-go-golems/glazed v0.5.7 h1:Papb53cZnb2kDezUHYGAEdy5wjO7VkcInBbm1xIZWM8=
-github.com/go-go-golems/glazed v0.5.7/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
+github.com/go-go-golems/glazed v0.5.8 h1:28/sBWfAgt4JYi+M3y/h27mSk5pRW2Og4Iim54fg61M=
+github.com/go-go-golems/glazed v0.5.8/go.mod h1:K1600pUk7xB/LKmvIafRWyfAdxE1sboruqQ9Jia8V9M=
 github.com/go-go-golems/sqleton v0.2.4 h1:qsgX0RxBXdjOC/+zmRrVvlsbBT8HCM2otLh/bV/f5uU=
 github.com/go-go-golems/sqleton v0.2.4/go.mod h1:GAGCz4/wsFwzN5mUA3ARmJfqanYu1k5yP4rCUiTeWgs=
 github.com/go-openapi/errors v0.20.3 h1:rz6kiC84sqNQoqrtulzaL/VERgkoCyB6WdEkc2ujzUc=

--- a/pkg/cmds/ls-commands/ls-commands.go
+++ b/pkg/cmds/ls-commands/ls-commands.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-go-golems/glazed/pkg/settings"
 	"github.com/go-go-golems/glazed/pkg/types"
 	"github.com/pkg/errors"
+	"strings"
 )
 
 type AddCommandToRowFunc func(cmd glazed_cmds.Command, row types.Row, parsedLayers *layers.ParsedLayers) ([]types.Row, error)
@@ -103,7 +104,7 @@ func (q *ListCommandsCommand) RunIntoGlazeProcessor(
 	for _, command := range q.commands {
 		description := command.Description()
 		obj := types.NewRow(
-			types.MRP("name", description.Name),
+			types.MRP("name", strings.Join(append(description.Parents, description.Name), " ")),
 			types.MRP("short", description.Short),
 			types.MRP("long", description.Long),
 			types.MRP("source", description.Source),


### PR DESCRIPTION
This pull request refactors the handling of directories and command aliases
within repositories:

- Enhance command listings (ls-commands) to include parent directories.
- Introduce `Directory` struct for better directory metadata management.
- Update `Repository` to use the `Directory` struct.
- Update `Watcher` to use the new directory handling approach.
