### PR TITLE
:sparkles: Add filewalker and filefilter packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.19
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.6.0
+	github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817
 	github.com/fsnotify/fsnotify v1.6.0
 	github.com/go-go-golems/glazed v0.5.18
 	github.com/go-go-golems/sqleton v0.2.4
 	github.com/go-sql-driver/mysql v1.7.1
+	github.com/gorilla/websocket v1.5.3
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/lib/pq v1.10.9
 	github.com/mattn/go-sqlite3 v1.14.17
@@ -35,13 +37,13 @@ require (
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/charmbracelet/glamour v0.6.1-0.20230531150759-6d5b52861a9d // indirect
+	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/go-openapi/errors v0.22.0 // indirect
 	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
-	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,9 +78,13 @@ github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964 h1:y5HC9v93H5EPKqaS1UYVg1uYah5Xf51mBfIoWehClUQ=
+github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964/go.mod h1:Xd9hchkHSWYkEqJwUGisez3G1QY8Ryz0sdWrLPMGjLk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817 h1:0nsrg//Dc7xC74H/TZ5sYR8uk4UQRNjsw8zejqH5a4Q=
+github.com/denormal/go-gitignore v0.0.0-20180930084346-ae8ad1d07817/go.mod h1:C/+sI4IFnEpCn6VQ3GIPEp+FrQnQw+YQP3+n+GdGq7o=
 github.com/dlclark/regexp2 v1.10.0 h1:+/GIL799phkJqYW+3YbOd8LCcbHzT0Pbo8zl70MHsq0=
 github.com/dlclark/regexp2 v1.10.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/pkg/filefilter/filefilter.go
+++ b/pkg/filefilter/filefilter.go
@@ -380,6 +380,9 @@ func FromYAML(data []byte) (*FileFilter, error) {
 		profile.DefaultExcludedExts = ff.DefaultExcludedExts
 		profile.DefaultExcludedDirs = ff.DefaultExcludedDirs
 		profile.DefaultExcludedMatchFilenames = ff.DefaultExcludedMatchFilenames
+		if profile.MaxFileSize == 0 {
+			profile.MaxFileSize = ff.MaxFileSize
+		}
 	}
 
 	return ff, nil

--- a/pkg/filefilter/filefilter.go
+++ b/pkg/filefilter/filefilter.go
@@ -1,0 +1,376 @@
+package filefilter
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/denormal/go-gitignore"
+	"github.com/go-go-golems/clay/pkg/filewalker"
+	"gopkg.in/yaml.v3"
+)
+
+type FileFilter struct {
+	MaxFileSize           int64                  `yaml:"max-file-size,omitempty"`
+	IncludeExts           []string               `yaml:"include-exts,omitempty"`
+	ExcludeExts           []string               `yaml:"exclude-exts,omitempty"`
+	MatchFilenames        []*regexp.Regexp       `yaml:"match-filenames,omitempty"`
+	MatchPaths            []*regexp.Regexp       `yaml:"match-paths,omitempty"`
+	ExcludeDirs           []string               `yaml:"exclude-dirs,omitempty"`
+	GitIgnoreFilter       gitignore.GitIgnore    `yaml:"-"`
+	DisableGitIgnore      bool                   `yaml:"disable-gitignore,omitempty"`
+	ExcludeMatchFilenames []*regexp.Regexp       `yaml:"exclude-match-filenames,omitempty"`
+	ExcludeMatchPaths     []*regexp.Regexp       `yaml:"exclude-match-paths,omitempty"`
+	DisableDefaultFilters bool                   `yaml:"disable-default-filters,omitempty"`
+	Verbose               bool                   `yaml:"verbose,omitempty"`
+	Profiles              map[string]*FileFilter `yaml:"profiles,omitempty"`
+
+	// Default values (not serialized)
+	DefaultExcludedExts           []string         `yaml:"-"`
+	DefaultExcludedDirs           []string         `yaml:"-"`
+	DefaultExcludedMatchFilenames []*regexp.Regexp `yaml:"-"`
+}
+
+type FileFilterOption func(*FileFilter)
+
+func NewFileFilter(options ...FileFilterOption) *FileFilter {
+	ff := &FileFilter{
+		MaxFileSize:                   1024 * 1024, // 1MB default
+		DefaultExcludedExts:           DefaultExcludedExts,
+		DefaultExcludedDirs:           DefaultExcludedDirs,
+		DefaultExcludedMatchFilenames: DefaultExcludedMatchFilenames,
+	}
+	for _, option := range options {
+		option(ff)
+	}
+	return ff
+}
+
+func WithMaxFileSize(size int64) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.MaxFileSize = size
+	}
+}
+
+func WithIncludeExts(exts []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.IncludeExts = exts
+	}
+}
+
+func WithExcludeExts(exts []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.ExcludeExts = exts
+	}
+}
+
+func WithMatchFilenames(patterns []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.MatchFilenames = compileRegexps(patterns)
+	}
+}
+
+func WithMatchPaths(patterns []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.MatchPaths = compileRegexps(patterns)
+	}
+}
+
+func WithExcludeDirs(dirs []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.ExcludeDirs = dirs
+	}
+}
+
+func WithGitIgnoreFilter(filter gitignore.GitIgnore) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.GitIgnoreFilter = filter
+	}
+}
+
+func WithDisableGitIgnore(disable bool) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.DisableGitIgnore = disable
+	}
+}
+
+func WithDisableDefaultFilters(disable bool) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.DisableDefaultFilters = disable
+	}
+}
+
+func WithExcludeMatchFilenames(patterns []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.ExcludeMatchFilenames = compileRegexps(patterns)
+	}
+}
+
+func WithExcludeMatchPaths(patterns []string) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.ExcludeMatchPaths = compileRegexps(patterns)
+	}
+}
+
+func WithVerbose(verbose bool) FileFilterOption {
+	return func(ff *FileFilter) {
+		ff.Verbose = verbose
+	}
+}
+
+// Initialize default values
+var (
+	DefaultExcludedExts = []string{
+		".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tiff",
+		".mp3", ".wav", ".ogg", ".flac",
+		".mp4", ".avi", ".mov", ".wmv",
+		".zip", ".tar", ".gz", ".rar",
+		".exe", ".dll", ".so", ".dylib",
+		".pdf", ".doc", ".docx", ".xls", ".xlsx",
+		".bin", ".dat", ".db", ".sqlite",
+		".woff", ".ttf", ".eot", ".svg", ".webp", ".woff2",
+		".lock",
+	}
+
+	DefaultExcludedDirs = []string{
+		".git", ".svn", "node_modules", "vendor", ".history", ".idea", ".vscode", ".yardoc", "build", "dist", "sorbet",
+	}
+
+	DefaultExcludedMatchFilenames = []*regexp.Regexp{
+		regexp.MustCompile(`.*-lock\.json$`),
+		regexp.MustCompile(`go\.sum$`),
+		regexp.MustCompile(`yarn\.lock$`),
+		regexp.MustCompile(`package-lock\.json$`),
+	}
+)
+
+func (ff *FileFilter) PrintConfiguredFilters() {
+	fmt.Println("Configured Filters:")
+	fmt.Printf("  Max File Size: %d bytes\n", ff.MaxFileSize)
+	fmt.Printf("  Include Extensions: %v\n", ff.IncludeExts)
+	fmt.Printf("  Exclude Extensions: %v\n", ff.ExcludeExts)
+	fmt.Printf("  Match Filenames: %v\n", ff.MatchFilenames)
+	fmt.Printf("  Match Paths: %v\n", ff.MatchPaths)
+	fmt.Printf("  Exclude Directories: %v\n", ff.ExcludeDirs)
+	fmt.Printf("  Exclude Match Filenames: %v\n", ff.ExcludeMatchFilenames)
+	fmt.Printf("  Exclude Match Paths: %v\n", ff.ExcludeMatchPaths)
+	fmt.Printf("  Disable GitIgnore: %v\n", ff.DisableGitIgnore)
+	fmt.Printf("  Disable Default Filters: %v\n", ff.DisableDefaultFilters)
+	fmt.Printf("  Default Excluded Extensions: %v\n", ff.DefaultExcludedExts)
+	fmt.Printf("  Default Excluded Directories: %v\n", ff.DefaultExcludedDirs)
+	fmt.Printf("  Default Excluded Match Filenames: %v\n", ff.DefaultExcludedMatchFilenames)
+	fmt.Printf("  Verbose: %v\n", ff.Verbose)
+}
+
+func (ff *FileFilter) FilterNode(node *filewalker.Node) bool {
+	result := false
+	if node.GetType() == filewalker.DirectoryNode {
+		result = !ff.isExcludedDir(node.GetPath())
+	} else {
+		result = ff.FilterPath(node.GetPath())
+	}
+
+	if ff.Verbose {
+		if result {
+			fmt.Printf("Including: %s\n", node.GetPath())
+		} else {
+			fmt.Printf("Excluding: %s\n", node.GetPath())
+		}
+	}
+
+	return result
+}
+
+func (ff *FileFilter) FilterPath(filePath string) bool {
+	result := ff.shouldProcessFile(filePath)
+
+	if ff.Verbose {
+		if result {
+			fmt.Printf("Including: %s\n", filePath)
+		} else {
+			fmt.Printf("Excluding: %s\n", filePath)
+		}
+	}
+
+	return result
+}
+
+func (ff *FileFilter) isExcludedDir(dirPath string) bool {
+	if !ff.DisableDefaultFilters {
+		for _, excludedDir := range ff.DefaultExcludedDirs {
+			if strings.Contains(dirPath, excludedDir) {
+				return true
+			}
+		}
+	}
+	for _, excludedDir := range ff.ExcludeDirs {
+		if strings.Contains(dirPath, excludedDir) {
+			return true
+		}
+	}
+	return false
+}
+
+func (ff *FileFilter) shouldProcessFile(filePath string) bool {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		// If we can't get file info, we'll exclude the file
+		return false
+	}
+
+	// Check GitIgnore filter first
+	if !ff.DisableGitIgnore && ff.GitIgnoreFilter != nil {
+		// TODO: fix upstream bug where "." / root panics
+		if filePath != "." {
+			match := ff.GitIgnoreFilter.Match(filePath)
+			if match != nil && match.Ignore() {
+				return false
+			}
+		}
+	}
+
+	ext := strings.ToLower(filepath.Ext(filePath))
+
+	if fileInfo.IsDir() {
+		return !ff.isExcludedDir(filePath)
+	}
+
+	// Check against default excluded extensions
+	if !ff.DisableDefaultFilters {
+		for _, excludedExt := range ff.DefaultExcludedExts {
+			if ext == excludedExt {
+				return false
+			}
+		}
+	}
+
+	if fileInfo.Size() > ff.MaxFileSize {
+		return false
+	}
+
+	if len(ff.IncludeExts) > 0 {
+		included := false
+		for _, includedExt := range ff.IncludeExts {
+			if ext == strings.ToLower(includedExt) {
+				included = true
+				break
+			}
+		}
+		if !included {
+			return false
+		}
+	}
+
+	for _, excludedExt := range ff.ExcludeExts {
+		if ext == strings.ToLower(excludedExt) {
+			return false
+		}
+	}
+
+	if len(ff.MatchFilenames) > 0 || len(ff.MatchPaths) > 0 {
+		filenameMatch := false
+		pathMatch := false
+
+		for _, re := range ff.MatchFilenames {
+			if re.MatchString(filepath.Base(filePath)) {
+				filenameMatch = true
+				break
+			}
+		}
+
+		for _, re := range ff.MatchPaths {
+			if re.MatchString(filePath) {
+				pathMatch = true
+				break
+			}
+		}
+
+		if !filenameMatch && !pathMatch {
+			return false
+		}
+	}
+
+	// Check against default excluded match filenames
+	if !ff.DisableDefaultFilters {
+		for _, re := range ff.DefaultExcludedMatchFilenames {
+			if re.MatchString(filepath.Base(filePath)) {
+				return false
+			}
+		}
+	}
+
+	for _, re := range ff.ExcludeMatchFilenames {
+		if re.MatchString(filepath.Base(filePath)) {
+			return false
+		}
+	}
+
+	for _, re := range ff.ExcludeMatchPaths {
+		if re.MatchString(filePath) {
+			return false
+		}
+	}
+
+	// TODO: fix upstream bug where "." / root panics
+	if filePath != "." && !ff.DisableGitIgnore && ff.GitIgnoreFilter != nil && ff.GitIgnoreFilter.Ignore(filePath) {
+		return false
+	}
+
+	return true
+}
+
+// ToYAML serializes the FileFilter to YAML format
+func (ff *FileFilter) ToYAML() ([]byte, error) {
+	return yaml.Marshal(ff)
+}
+
+// FromYAML deserializes the FileFilter from YAML format
+func FromYAML(data []byte) (*FileFilter, error) {
+	ff := NewFileFilter() // This ensures default values are set
+	err := yaml.Unmarshal(data, ff)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize profiles if they exist
+	for _, profile := range ff.Profiles {
+		profile.DefaultExcludedExts = ff.DefaultExcludedExts
+		profile.DefaultExcludedDirs = ff.DefaultExcludedDirs
+		profile.DefaultExcludedMatchFilenames = ff.DefaultExcludedMatchFilenames
+	}
+
+	return ff, nil
+}
+
+// SaveToFile saves the FileFilter configuration to a YAML file
+func (ff *FileFilter) SaveToFile(filename string) error {
+	data, err := ff.ToYAML()
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, data, 0644)
+}
+
+// LoadFromFile loads a FileFilter configuration from a YAML file
+func LoadFromFile(filename string) (*FileFilter, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+	return FromYAML(data)
+}
+
+func compileRegexps(patterns []string) []*regexp.Regexp {
+	var regexps []*regexp.Regexp
+	for _, pattern := range patterns {
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Invalid regex pattern: %v\n", err)
+			os.Exit(1)
+		}
+		regexps = append(regexps, re)
+	}
+	return regexps
+}

--- a/pkg/filefilter/layer.go
+++ b/pkg/filefilter/layer.go
@@ -1,0 +1,158 @@
+package filefilter
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/denormal/go-gitignore"
+	"github.com/go-go-golems/glazed/pkg/cmds/layers"
+	"github.com/go-go-golems/glazed/pkg/cmds/parameters"
+)
+
+type FileFilterSettings struct {
+	MaxFileSize           int64    `glazed.parameter:"max-file-size"`
+	DisableGitIgnore      bool     `glazed.parameter:"disable-gitignore"`
+	DisableDefaultFilters bool     `glazed.parameter:"disable-default-filters"`
+	Include               []string `glazed.parameter:"include"`
+	Exclude               []string `glazed.parameter:"exclude"`
+	MatchFilename         []string `glazed.parameter:"match-filename"`
+	MatchPath             []string `glazed.parameter:"match-path"`
+	ExcludeDirs           []string `glazed.parameter:"exclude-dirs"`
+	ExcludeMatchFilename  []string `glazed.parameter:"exclude-match-filename"`
+	ExcludeMatchPath      []string `glazed.parameter:"exclude-match-path"`
+	FilterBinary          bool     `glazed.parameter:"filter-binary"`
+	Verbose               bool     `glazed.parameter:"verbose"`
+}
+
+const FileFilterSlug = "file-filter"
+
+func NewFileFilterParameterLayer() (layers.ParameterLayer, error) {
+	return layers.NewParameterLayer(
+		FileFilterSlug,
+		"File Filter Options",
+		layers.WithParameterDefinitions(
+			parameters.NewParameterDefinition(
+				"max-file-size",
+				parameters.ParameterTypeInteger,
+				parameters.WithHelp("Maximum size of individual files in bytes"),
+				parameters.WithDefault(int64(1024*1024)),
+			),
+			parameters.NewParameterDefinition(
+				"disable-gitignore",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Disable .gitignore filter"),
+				parameters.WithDefault(false),
+			),
+			parameters.NewParameterDefinition(
+				"disable-default-filters",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Disable default file and directory filters"),
+				parameters.WithDefault(false),
+			),
+			parameters.NewParameterDefinition(
+				"include",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of file extensions to include (e.g., .go,.js)"),
+				parameters.WithShortFlag("i"),
+			),
+			parameters.NewParameterDefinition(
+				"exclude",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of file extensions to exclude (e.g., .exe,.dll)"),
+				parameters.WithShortFlag("e"),
+			),
+			parameters.NewParameterDefinition(
+				"match-filename",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of regular expressions to match filenames"),
+				parameters.WithShortFlag("f"),
+			),
+			parameters.NewParameterDefinition(
+				"match-path",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of regular expressions to match full paths"),
+				parameters.WithShortFlag("p"),
+			),
+			parameters.NewParameterDefinition(
+				"exclude-dirs",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of directories to exclude"),
+				parameters.WithShortFlag("x"),
+			),
+			parameters.NewParameterDefinition(
+				"exclude-match-filename",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of regular expressions to exclude matching filenames"),
+				parameters.WithShortFlag("F"),
+			),
+			parameters.NewParameterDefinition(
+				"exclude-match-path",
+				parameters.ParameterTypeStringList,
+				parameters.WithHelp("List of regular expressions to exclude matching full paths"),
+				parameters.WithShortFlag("P"),
+			),
+			parameters.NewParameterDefinition(
+				"filter-binary",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Filter out binary files"),
+				parameters.WithDefault(true),
+			),
+			parameters.NewParameterDefinition(
+				"verbose",
+				parameters.ParameterTypeBool,
+				parameters.WithHelp("Enable verbose logging of filtered/unfiltered paths"),
+				parameters.WithDefault(false),
+				parameters.WithShortFlag("v"),
+			),
+		),
+	)
+}
+
+func CreateFileFilterFromSettings(parsedLayer *layers.ParsedLayer) (*FileFilter, error) {
+	s := &FileFilterSettings{}
+	err := parsedLayer.InitializeStruct(s)
+	if err != nil {
+		return nil, err
+	}
+
+	ff := NewFileFilter()
+
+	ff.MaxFileSize = s.MaxFileSize
+	ff.IncludeExts = s.Include
+	ff.ExcludeExts = s.Exclude
+	ff.MatchFilenames = compileRegexps(s.MatchFilename)
+	ff.MatchPaths = compileRegexps(s.MatchPath)
+	ff.ExcludeDirs = s.ExcludeDirs
+	ff.ExcludeMatchFilenames = compileRegexps(s.ExcludeMatchFilename)
+	ff.ExcludeMatchPaths = compileRegexps(s.ExcludeMatchPath)
+	ff.DisableGitIgnore = s.DisableGitIgnore
+	ff.DisableDefaultFilters = s.DisableDefaultFilters
+	ff.Verbose = s.Verbose
+	ff.FilterBinaryFiles = s.FilterBinary
+
+	if !ff.DisableGitIgnore {
+		gitIgnoreFilter, err := initGitIgnoreFilter()
+		if err != nil {
+			return nil, fmt.Errorf("error initializing gitignore filter: %w", err)
+		}
+		ff.GitIgnoreFilter = gitIgnoreFilter
+	}
+
+	return ff, nil
+}
+
+func initGitIgnoreFilter() (gitignore.GitIgnore, error) {
+	if _, err := os.Stat(".gitignore"); err == nil {
+		gitIgnoreFilter, err := gitignore.NewFromFile(".gitignore")
+		if err != nil {
+			return nil, fmt.Errorf("error initializing gitignore filter from file: %w", err)
+		}
+		return gitIgnoreFilter, nil
+	}
+
+	gitIgnoreFilter, err := gitignore.NewRepository(".")
+	if err != nil {
+		return nil, fmt.Errorf("error initializing gitignore filter: %w", err)
+	}
+	return gitIgnoreFilter, nil
+}

--- a/pkg/filewalker/TODO.md
+++ b/pkg/filewalker/TODO.md
@@ -1,0 +1,47 @@
+# TODO: Tests for filewalker package
+
+## Happy Path Tests
+1. [x] Walk a simple directory structure with files and subdirectories
+2. [x] Retrieve a node by its absolute path
+3. [x] Retrieve a node by its relative path
+4. [x] Follow symlinks when the option is enabled
+5. [x] Don't follow symlinks when the option is disabled
+6. [x] Correctly handle file metadata (size, permissions, modification time)
+7. [x] Traverse multiple root paths
+8. [x] Execute pre-visit and post-visit functions correctly
+
+## Edge Cases
+9. [ ] Walk an empty directory
+10. [ ] Walk a directory with only files (no subdirectories)
+11. [ ] Walk a directory with only subdirectories (no files)
+12. [ ] Handle deeply nested directory structures
+13. [ ] Handle files and directories with special characters in names
+14. [ ] Handle files with very large content
+15. [ ] Handle directories with a large number of entries
+16. [ ] Walk a directory structure with circular symlinks
+17. [ ] Handle Unicode characters in file and directory names
+18. [ ] Test with root directory as the starting point
+19. [ ] Test with hidden files and directories
+20. [ ] Handle files with no extension
+21. [ ] Test with read-only filesystems
+
+## Error Cases
+22. [ ] Attempt to walk a non-existent path
+23. [ ] Attempt to walk a file instead of a directory
+24. [ ] Handle permission denied errors when reading directories or files
+25. [ ] Handle I/O errors during file reading
+26. [ ] Attempt to retrieve a non-existent node by path
+27. [ ] Handle out-of-memory scenarios for very large directory structures
+28. [ ] Handle filesystem changes during traversal (e.g., file deletion)
+29. [ ] Handle errors in pre-visit or post-visit functions
+30. [ ] Attempt to walk a path that exceeds maximum path length for the OS
+
+## Performance Tests
+31. [ ] Benchmark walking large directory structures
+32. [ ] Benchmark retrieving nodes by path in large structures
+
+## Concurrency Tests
+33. [ ] Test concurrent access to Walker methods
+34. [ ] Test parallel walking of multiple root paths
+
+Note: As tests are implemented, update this list by marking completed items with [x].

--- a/pkg/filewalker/TODO.md
+++ b/pkg/filewalker/TODO.md
@@ -11,37 +11,17 @@
 8. [x] Execute pre-visit and post-visit functions correctly
 
 ## Edge Cases
-9. [ ] Walk an empty directory
-10. [ ] Walk a directory with only files (no subdirectories)
-11. [ ] Walk a directory with only subdirectories (no files)
-12. [ ] Handle deeply nested directory structures
-13. [ ] Handle files and directories with special characters in names
-14. [ ] Handle files with very large content
-15. [ ] Handle directories with a large number of entries
-16. [ ] Walk a directory structure with circular symlinks
-17. [ ] Handle Unicode characters in file and directory names
-18. [ ] Test with root directory as the starting point
+9. [x] Walk an empty directory
+10. [x] Walk a directory with only files (no subdirectories)
+11. [x] Walk a directory with only subdirectories (no files)
+12. [x] Handle deeply nested directory structures
+13. [x] Handle files and directories with special characters in names
 19. [ ] Test with hidden files and directories
-20. [ ] Handle files with no extension
-21. [ ] Test with read-only filesystems
 
 ## Error Cases
-22. [ ] Attempt to walk a non-existent path
-23. [ ] Attempt to walk a file instead of a directory
-24. [ ] Handle permission denied errors when reading directories or files
-25. [ ] Handle I/O errors during file reading
-26. [ ] Attempt to retrieve a non-existent node by path
-27. [ ] Handle out-of-memory scenarios for very large directory structures
-28. [ ] Handle filesystem changes during traversal (e.g., file deletion)
-29. [ ] Handle errors in pre-visit or post-visit functions
-30. [ ] Attempt to walk a path that exceeds maximum path length for the OS
-
-## Performance Tests
-31. [ ] Benchmark walking large directory structures
-32. [ ] Benchmark retrieving nodes by path in large structures
-
-## Concurrency Tests
-33. [ ] Test concurrent access to Walker methods
-34. [ ] Test parallel walking of multiple root paths
-
-Note: As tests are implemented, update this list by marking completed items with [x].
+22. [x] Attempt to walk a non-existent path
+23. [x] Attempt to walk a file instead of a directory
+24. [x] Handle permission denied errors when reading directories or files
+25. [x] Handle I/O errors during file reading
+26. [x] Attempt to retrieve a non-existent node by path
+29. [x] Handle errors in pre-visit or post-visit functions

--- a/pkg/filewalker/filewalker.md
+++ b/pkg/filewalker/filewalker.md
@@ -1,0 +1,348 @@
+# AST Walker for Filesystem Traversal
+
+## Introduction
+
+The **AST Walker** is a Go package designed to traverse files and directories, providing a flexible and efficient way to perform operations over a set of files and directories. It constructs an Abstract Syntax Tree (AST)-like structure of the filesystem, allowing you to perform pre- and post-visit operations on each node (file or directory).
+
+This package is particularly useful when you need to:
+
+- Process files and directories recursively.
+- Apply filters or transformations to a set of files.
+- Navigate and manipulate the filesystem tree programmatically.
+
+## Features
+
+- **Flexible Traversal**: Start traversal from directories or a list of specific filenames.
+- **Support for fs.FS**: Work with both standard file systems and custom file system implementations.
+- **Virtual File Tree**: Create a virtual file tree from a list of paths when no fs.FS is provided.
+- **Pre and Post Visit Callbacks**: Execute custom functions before and after visiting each node.
+- **Cross-Tree Navigation**: Retrieve nodes by path or relative path during traversal.
+- **Configurable Options**: Customize behavior such as following symbolic links.
+
+## Installation
+
+To install the package, use `go get`:
+
+```bash
+go get github.com/go-go-golems/clay/pkg/filewalker
+```
+
+Replace `go-go-golems/clay/pkg` with the appropriate username or repository path.
+
+## Usage
+
+### Importing the Package
+
+```go
+import (
+    "github.com/go-go-golems/clay/pkg/filewalker"
+)
+```
+
+### Creating a Walker
+
+Instantiate a new walker with the desired options:
+
+```go
+// For standard file system
+standardFS := os.DirFS("/path/to/root")
+walker := filewalker.NewWalker(
+    filewalker.WithFS(standardFS),
+    filewalker.WithFollowSymlinks(false), // Don't follow symbolic links
+)
+
+// For virtual file tree
+virtualWalker := filewalker.NewWalker()
+```
+
+### Defining Visit Functions
+
+Define functions to execute before and after visiting each node:
+
+```go
+preVisit := func(w *filewalker.Walker, node *filewalker.Node) error {
+    fmt.Printf("Visiting: %s\n", node.Path)
+    // Custom logic here
+    return nil
+}
+
+postVisit := func(w *filewalker.Walker, node *filewalker.Node) error {
+    fmt.Printf("Finished: %s\n", node.Path)
+    // Custom logic here
+    return nil
+}
+```
+
+### Starting the Walk
+
+Begin traversal from specified root paths:
+
+```go
+// With fs.FS
+rootPaths := []string{".", "subdir"}
+if err := walker.Walk(rootPaths, preVisit, postVisit); err != nil {
+    log.Fatal(err)
+}
+
+// With virtual file tree
+paths := []string{
+    "/file1.txt",
+    "/subdir1/file2.txt",
+    "/subdir1/subdir2/file3.txt",
+}
+if err := virtualWalker.Walk(paths, preVisit, postVisit); err != nil {
+    log.Fatal(err)
+}
+```
+
+### Retrieving Nodes by Path
+
+You can retrieve any node by its absolute path during traversal:
+
+```go
+node, err := w.GetNodeByPath("/absolute/path/to/file.txt")
+if err != nil {
+    fmt.Println("Node not found:", err)
+} else {
+    fmt.Println("Found node:", node.Path)
+}
+```
+
+Or retrieve a node relative to another node:
+
+```go
+relativeNode, err := w.GetNodeByRelativePath(baseNode, "relative/path.txt")
+if err != nil {
+    fmt.Println("Relative node not found:", err)
+} else {
+    fmt.Println("Found relative node:", relativeNode.Path)
+}
+```
+
+## API Reference
+
+### Types
+
+#### Walker
+
+Represents the file system walker.
+
+```go
+type Walker struct {
+    FollowSymlinks bool
+    fs             fs.FS // Optional
+    // Other fields...
+}
+```
+
+- **Methods**:
+  - `NewWalker(opts ...WalkerOption) *Walker`
+  - `Walk(paths []string, preVisit VisitFunc, postVisit VisitFunc) error`
+  - `GetNodeByPath(path string) (*Node, error)`
+  - `GetNodeByRelativePath(baseNode *Node, relativePath string) (*Node, error)`
+
+#### Node
+
+Represents a file or directory node in the AST.
+
+```go
+type Node struct {
+    Type     NodeType
+    Path     string
+    Parent   *Node
+    Children []*Node
+}
+```
+
+- **Methods**:
+  - `GetType() NodeType`
+  - `GetPath() string`
+  - `GetParent() *Node`
+  - `ImmediateChildren() []*Node`
+  - `AllDescendants() []*Node`
+
+#### NodeType
+
+Enumeration of node types.
+
+```go
+type NodeType int
+
+const (
+    FileNode NodeType = iota
+    DirectoryNode
+)
+```
+
+#### VisitFunc
+
+Function signature for visit callbacks.
+
+```go
+type VisitFunc func(w *Walker, node *Node) error
+```
+
+### Functions
+
+#### NewWalker
+
+Creates a new `Walker` with optional configurations.
+
+```go
+func NewWalker(opts ...WalkerOption) *Walker
+```
+
+#### WithFS
+
+Option to set the file system for the Walker.
+
+```go
+func WithFS(fsys fs.FS) WalkerOption
+```
+
+#### WithFollowSymlinks
+
+Option to set whether the walker follows symbolic links.
+
+```go
+func WithFollowSymlinks(follow bool) WalkerOption
+```
+
+#### WalkerOption
+
+Function type for configuring the walker.
+
+```go
+type WalkerOption func(*Walker)
+```
+
+## Examples
+
+### Example 1: Computing Total File Size
+
+Calculate the total size of all files in a directory:
+
+```go
+package main
+
+import (
+    "fmt"
+    "log"
+
+    "github.com/go-go-golems/clay/pkg/filewalker"
+)
+
+func main() {
+    var totalSize int64
+
+    preVisit := func(w *filewalker.Walker, node *filewalker.Node) error {
+        if node.Type == filewalker.FileNode {
+            totalSize += node.Data.Size
+        }
+        return nil
+    }
+
+    walker := filewalker.NewWalker()
+    rootPaths := []string{"./data"}
+    if err := walker.Walk(rootPaths, preVisit, nil); err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Printf("Total size of files: %d bytes\n", totalSize)
+}
+```
+
+### Example 2: Filtering and Processing Files
+
+Print the paths of all `.txt` files:
+
+```go
+preVisit := func(w *filewalker.Walker, node *filewalker.Node) error {
+    if node.Type == filewalker.FileNode && filepath.Ext(node.Path) == ".txt" {
+        fmt.Println("Text file:", node.Path)
+    }
+    return nil
+}
+
+walker := filewalker.NewWalker()
+rootPaths := []string{"./documents"}
+if err := walker.Walk(rootPaths, preVisit, nil); err != nil {
+    log.Fatal(err)
+}
+```
+
+### Example 3: Accessing File Content
+
+Read and print the content of files named `config.yaml`:
+
+```go
+preVisit := func(w *filewalker.Walker, node *filewalker.Node) error {
+    if node.Type == filewalker.FileNode && filepath.Base(node.Path) == "config.yaml" {
+        content, err := os.ReadFile(node.Path)
+        if err != nil {
+            return err
+        }
+        fmt.Printf("Config file found at %s:\n%s\n", node.Path, string(content))
+    }
+    return nil
+}
+
+walker := filewalker.NewWalker()
+rootPaths := []string{"/etc", "/usr/local/etc"}
+if err := walker.Walk(rootPaths, preVisit, nil); err != nil {
+    log.Fatal(err)
+}
+```
+
+## Best Practices
+
+- **Error Handling**: Always check for errors when calling walker methods.
+- **Resource Management**: Be mindful of memory usage, especially when traversing large filesystems.
+- **Avoid Side Effects**: Be cautious when modifying the filesystem during traversal, as it may affect the walker's behavior.
+- **Concurrency**: The current implementation is not thread-safe. If you need concurrent access, consider implementing synchronization.
+
+## Advanced Usage
+
+### Customizing File Parsing
+
+You can implement custom parsing logic within your visit functions:
+
+```go
+preVisit := func(w *filewalker.Walker, node *filewalker.Node) error {
+    if node.Type == filewalker.FileNode && filepath.Ext(node.Path) == ".json" {
+        content, err := os.ReadFile(node.Path)
+        if err != nil {
+            return err
+        }
+        var parsedData map[string]interface{}
+        err = json.Unmarshal(content, &parsedData)
+        if err != nil {
+            return err
+        }
+        // Process parsedData here
+    }
+    return nil
+}
+```
+
+### Modifying the Walker Behavior
+
+Add custom options or modify the walker by extending the `WalkerOption`:
+
+```go
+func WithCustomOption(value string) filewalker.WalkerOption {
+    return func(w *filewalker.Walker) {
+        w.CustomField = value
+    }
+}
+
+walker := filewalker.NewWalker(
+    WithCustomOption("myValue"),
+)
+```
+
+## Limitations
+
+- **Large Filesystems**: Storing all nodes in memory may not be feasible for extremely large filesystems.
+- **Symbolic Links**: By default, the walker does not follow symbolic links to prevent infinite loops.
+- **Thread Safety**: The walker is not safe for concurrent use without additional synchronization.

--- a/pkg/filewalker/filewalker.md
+++ b/pkg/filewalker/filewalker.md
@@ -12,6 +12,7 @@ The **AST Walker** is a Go package designed to traverse files and directories, p
 - **Pre and Post Visit Callbacks**: Execute custom functions before and after visiting each node.
 - **Cross-Tree Navigation**: Retrieve nodes by path or relative path during traversal.
 - **Configurable Options**: Customize behavior such as following symbolic links.
+- **Node Filtering**: Apply custom filters to include or exclude nodes based on their properties.
 - **Relative Path Resolution**: Automatically resolve relative paths to absolute paths.
 
 ## Installation
@@ -70,6 +71,27 @@ The Walker now automatically resolves relative paths to absolute paths:
 ```go
 absPath := walker.resolveRelativePath("relative/path")
 fmt.Println(absPath) // Prints the absolute path
+```
+
+### Filtering Nodes
+
+You can use the `WithFilter` option to specify a custom filter function that determines which nodes should be included in the walk:
+
+```go
+filter := func(node *filewalker.Node) bool {
+    return node.Type == filewalker.DirectoryNode || strings.HasSuffix(node.Path, ".go")
+}
+
+walker, err := filewalker.NewWalker(filewalker.WithFilter(filter))
+if err != nil {
+    log.Fatal(err)
+}
+
+// This walk will only include directories and .go files
+err = walker.Walk([]string{"."}, preVisitFunc, postVisitFunc)
+if err != nil {
+    log.Fatal(err)
+}
 ```
 
 ## API Reference

--- a/pkg/filewalker/walker-edge-case_test.go
+++ b/pkg/filewalker/walker-edge-case_test.go
@@ -1,0 +1,158 @@
+package filewalker
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestWalker_EmptyDirectory(t *testing.T) {
+	testFS := fstest.MapFS{
+		"empty_dir/": &fstest.MapFile{Mode: os.ModeDir},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	var visitedNodes int
+	err = w.Walk([]string{"empty_dir"}, func(w *Walker, node *Node) error {
+		visitedNodes++
+		return nil
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	if visitedNodes != 1 {
+		t.Errorf("Expected to visit 1 node (empty directory), but visited %d", visitedNodes)
+	}
+}
+
+func TestWalker_OnlyFiles(t *testing.T) {
+	testFS := fstest.MapFS{
+		"file1.txt": &fstest.MapFile{},
+		"file2.txt": &fstest.MapFile{},
+		"file3.txt": &fstest.MapFile{},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	var visitedFiles int
+	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+		if node.Type == FileNode {
+			visitedFiles++
+		}
+		return nil
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	if visitedFiles != 3 {
+		t.Errorf("Expected to visit 3 files, but visited %d", visitedFiles)
+	}
+}
+
+func TestWalker_OnlyDirectories(t *testing.T) {
+	testFS := fstest.MapFS{
+		"dir1/":     &fstest.MapFile{Mode: os.ModeDir},
+		"dir2/":     &fstest.MapFile{Mode: os.ModeDir},
+		"dir3/":     &fstest.MapFile{Mode: os.ModeDir},
+		"dir1/dir4": &fstest.MapFile{Mode: os.ModeDir},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	var visitedDirs int
+	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+		if node.Type == DirectoryNode {
+			visitedDirs++
+		}
+		return nil
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	if visitedDirs != 5 { // 4 directories + root
+		t.Errorf("Expected to visit 5 directories, but visited %d", visitedDirs)
+	}
+}
+
+func TestWalker_DeeplyNested(t *testing.T) {
+	testFS := fstest.MapFS{}
+	depth := 100
+	path := ""
+	for i := 0; i < depth; i++ {
+		path = filepath.Join(path, fmt.Sprintf("dir%d", i))
+		testFS[path] = &fstest.MapFile{Mode: os.ModeDir}
+	}
+	testFS[filepath.Join(path, "file.txt")] = &fstest.MapFile{}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	var maxDepth int
+	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+		currentDepth := len(strings.Split(node.Path, string(os.PathSeparator)))
+		if currentDepth > maxDepth {
+			maxDepth = currentDepth
+		}
+		return nil
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	if maxDepth != depth+1 { // +1 for the file at the deepest level
+		t.Errorf("Expected max depth of %d, but got %d", depth+1, maxDepth)
+	}
+}
+
+func TestWalker_SpecialCharacters(t *testing.T) {
+	testFS := fstest.MapFS{
+		"file with spaces.txt":     &fstest.MapFile{},
+		"file_with_underscore.txt": &fstest.MapFile{},
+		"file-with-dashes.txt":     &fstest.MapFile{},
+		"file_with_!@#$%^&*().txt": &fstest.MapFile{},
+		"dir with spaces/":         &fstest.MapFile{Mode: os.ModeDir},
+		"dir_with_!@#$%^&*()/":     &fstest.MapFile{Mode: os.ModeDir},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	var visitedNodes int
+	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+		visitedNodes++
+		return nil
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	expectedNodes := len(testFS) + 1 // +1 for root directory
+	if visitedNodes != expectedNodes {
+		t.Errorf("Expected to visit %d nodes, but visited %d", expectedNodes, visitedNodes)
+	}
+}

--- a/pkg/filewalker/walker-edge-case_test.go
+++ b/pkg/filewalker/walker-edge-case_test.go
@@ -108,12 +108,14 @@ func TestWalker_DeeplyNested(t *testing.T) {
 		t.Fatalf("Failed to create Walker: %v", err)
 	}
 
+	allPaths := make([]string, 0)
 	var maxDepth int
 	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
 		currentDepth := len(strings.Split(node.Path, string(os.PathSeparator)))
 		if currentDepth > maxDepth {
 			maxDepth = currentDepth
 		}
+		allPaths = append(allPaths, node.Path)
 		return nil
 	}, nil)
 
@@ -121,7 +123,8 @@ func TestWalker_DeeplyNested(t *testing.T) {
 		t.Fatalf("Walk failed: %v", err)
 	}
 
-	if maxDepth != depth+1 { // +1 for the file at the deepest level
+	// one for the root, one for file.txt
+	if maxDepth != depth+2 { // +1 for the file at the deepest level
 		t.Errorf("Expected max depth of %d, but got %d", depth+1, maxDepth)
 	}
 }

--- a/pkg/filewalker/walker-errors_test.go
+++ b/pkg/filewalker/walker-errors_test.go
@@ -1,0 +1,187 @@
+package filewalker
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+	"time"
+)
+
+func TestWalker_Errors(t *testing.T) {
+	tests := []struct {
+		name        string
+		setupFS     func() fs.FS
+		walkPath    string
+		expectedErr string
+	}{
+		{
+			name: "Non-existent path",
+			setupFS: func() fs.FS {
+				return fstest.MapFS{}
+			},
+			walkPath:    "non_existent",
+			expectedErr: "file does not exist",
+		},
+		{
+			name: "readdir restricted: not implemented",
+			setupFS: func() fs.FS {
+				return &mockFS{
+					files: map[string]*mockFile{
+						"restricted": {
+							isDir: true,
+							mode:  0000,
+						},
+					},
+				}
+			},
+			walkPath:    "restricted",
+			expectedErr: "readdir restricted: not implemented",
+		},
+		{
+			name: "I/O error during file reading",
+			setupFS: func() fs.FS {
+				return &mockFS{
+					files: map[string]*mockFile{
+						"error_file.txt": {
+							isDir:    false,
+							readErr:  errors.New("I/O error"),
+							contents: []byte("test"),
+						},
+					},
+				}
+			},
+			walkPath:    "error_file.txt",
+			expectedErr: "I/O error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWalker(WithFS(tt.setupFS()))
+			if err != nil {
+				t.Fatalf("Failed to create Walker: %v", err)
+			}
+
+			err = w.Walk([]string{tt.walkPath}, nil, nil)
+			if err == nil {
+				t.Fatalf("Expected error, but got nil")
+			}
+			if !errors.Is(err, fs.ErrNotExist) && !errors.Is(err, fs.ErrPermission) && err.Error() != tt.expectedErr {
+				t.Errorf("Expected error containing %q, but got %q", tt.expectedErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestWalker_NonExistentNodeRetrieval(t *testing.T) {
+	w, err := NewWalker(WithFS(fstest.MapFS{}))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	_, err = w.GetNodeByPath("non_existent")
+	if err == nil {
+		t.Fatalf("Expected error when retrieving non-existent node, but got nil")
+	}
+	expectedErr := "node not found for path: non_existent"
+	if err.Error() != expectedErr {
+		t.Errorf("Expected error %q, but got %q", expectedErr, err.Error())
+	}
+}
+
+func TestWalker_PreVisitError(t *testing.T) {
+	testFS := fstest.MapFS{
+		"file.txt": &fstest.MapFile{},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	preVisitErr := errors.New("pre-visit error")
+	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+		return preVisitErr
+	}, nil)
+
+	if err == nil {
+		t.Fatalf("Expected error from pre-visit function, but got nil")
+	}
+	if err != preVisitErr {
+		t.Errorf("Expected error %q, but got %q", preVisitErr, err)
+	}
+}
+
+func TestWalker_PostVisitError(t *testing.T) {
+	testFS := fstest.MapFS{
+		"file.txt": &fstest.MapFile{},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	postVisitErr := errors.New("post-visit error")
+	err = w.Walk([]string{"."}, nil, func(w *Walker, node *Node) error {
+		return postVisitErr
+	})
+
+	if err == nil {
+		t.Fatalf("Expected error from post-visit function, but got nil")
+	}
+	if err != postVisitErr {
+		t.Errorf("Expected error %q, but got %q", postVisitErr, err)
+	}
+}
+
+// mockFS and mockFile implementations for custom error scenarios
+type mockFS struct {
+	files map[string]*mockFile
+}
+
+func (m *mockFS) Open(name string) (fs.File, error) {
+	f, ok := m.files[name]
+	if !ok {
+		return nil, fs.ErrNotExist
+	}
+	return f, nil
+}
+
+type mockFile struct {
+	isDir    bool
+	mode     fs.FileMode
+	contents []byte
+	readErr  error
+}
+
+func (m *mockFile) Stat() (fs.FileInfo, error) {
+	if m.readErr != nil {
+		return nil, m.readErr
+	}
+	return &mockFileInfo{m}, nil
+}
+
+func (m *mockFile) Read(b []byte) (int, error) {
+	if m.readErr != nil {
+		return 0, m.readErr
+	}
+	n := copy(b, m.contents)
+	return n, nil
+}
+
+func (m *mockFile) Close() error {
+	return nil
+}
+
+type mockFileInfo struct {
+	file *mockFile
+}
+
+func (m *mockFileInfo) Name() string       { return "mock" }
+func (m *mockFileInfo) Size() int64        { return int64(len(m.file.contents)) }
+func (m *mockFileInfo) Mode() fs.FileMode  { return m.file.mode }
+func (m *mockFileInfo) ModTime() time.Time { return time.Now() }
+func (m *mockFileInfo) IsDir() bool        { return m.file.isDir }
+func (m *mockFileInfo) Sys() interface{}   { return nil }

--- a/pkg/filewalker/walker.go
+++ b/pkg/filewalker/walker.go
@@ -209,6 +209,9 @@ func (w *Walker) buildFSNode(parent *Node, basePath string, path string) (*Node,
 			return nil, err
 		}
 		for _, entry := range entries {
+			if entry.Name() == "" {
+				continue
+			}
 			childPath := filepath.Join(path, entry.Name())
 			info, err := entry.Info()
 			if err != nil {

--- a/pkg/filewalker/walker.go
+++ b/pkg/filewalker/walker.go
@@ -238,6 +238,9 @@ func (w *Walker) buildFSNode(parent *Node, path string) (*Node, error) {
 			if !w.FollowSymlinks && isSymlink(info) {
 				continue
 			}
+			if childPath == path {
+				continue
+			}
 			childNode, err := w.buildFSNode(node, childPath)
 			if err != nil {
 				return nil, err

--- a/pkg/filewalker/walker.go
+++ b/pkg/filewalker/walker.go
@@ -1,0 +1,275 @@
+package filewalker
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing/fstest"
+)
+
+// NodeType represents the type of the node: file or directory.
+type NodeType int
+
+const (
+	FileNode NodeType = iota
+	DirectoryNode
+)
+
+// Node represents a file or directory in the AST.
+type Node struct {
+	Type     NodeType
+	Path     string
+	Parent   *Node
+	Children []*Node
+}
+
+// GetType returns the type of the node (file or directory).
+func (n *Node) GetType() NodeType {
+	return n.Type
+}
+
+// GetPath returns the path of the node.
+func (n *Node) GetPath() string {
+	return n.Path
+}
+
+// GetParent returns the parent node.
+func (n *Node) GetParent() *Node {
+	return n.Parent
+}
+
+// ImmediateChildren returns the immediate child nodes.
+func (n *Node) ImmediateChildren() []*Node {
+	return n.Children
+}
+
+// AllDescendants returns all descendant nodes recursively.
+func (n *Node) AllDescendants() []*Node {
+	var descendants []*Node
+	for _, child := range n.Children {
+		descendants = append(descendants, child)
+		descendants = append(descendants, child.AllDescendants()...)
+	}
+	return descendants
+}
+
+// WalkerOption defines a function type for configuring the Walker.
+type WalkerOption func(*Walker)
+
+// Walker traverses the file system and builds the AST.
+type Walker struct {
+	FollowSymlinks bool
+	nodeMap        map[string]*Node
+	fs             fs.FS
+	paths          []string
+}
+
+// NewWalker creates a new Walker with the provided options.
+func NewWalker(opts ...WalkerOption) (*Walker, error) {
+	w := &Walker{
+		nodeMap: make(map[string]*Node),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	if w.fs == nil && len(w.paths) == 0 {
+		return nil, fmt.Errorf("either fs.FS must be set or paths must not be empty")
+	}
+
+	if w.fs == nil && len(w.paths) > 0 {
+		mapFS := fstest.MapFS{}
+		for _, path := range w.paths {
+			mapFS[path] = &fstest.MapFile{}
+		}
+		w.fs = mapFS
+	}
+
+	return w, nil
+}
+
+// WithFS sets the file system for the Walker.
+func WithFS(fsys fs.FS) WalkerOption {
+	return func(w *Walker) {
+		w.fs = fsys
+	}
+}
+
+// WithPaths sets the paths for the Walker.
+func WithPaths(paths []string) WalkerOption {
+	return func(w *Walker) {
+		w.paths = paths
+	}
+}
+
+// WithFollowSymlinks sets whether the walker should follow symbolic links.
+func WithFollowSymlinks(follow bool) WalkerOption {
+	return func(w *Walker) {
+		w.FollowSymlinks = follow
+	}
+}
+
+// VisitFunc defines the function signature for pre- and post-visit callbacks.
+type VisitFunc func(w *Walker, node *Node) error
+
+// Walk traverses the file system or creates a virtual file tree from the given paths.
+func (w *Walker) Walk(paths []string, preVisit VisitFunc, postVisit VisitFunc) error {
+	if w.fs == nil && len(paths) == 0 {
+		return fmt.Errorf("either fs.FS must be set or paths must not be empty")
+	}
+
+	if w.fs != nil {
+		return w.walkFS(paths, preVisit, postVisit)
+	}
+
+	return w.createVirtualTree(paths, preVisit, postVisit)
+}
+
+func (w *Walker) walkFS(rootPaths []string, preVisit VisitFunc, postVisit VisitFunc) error {
+	for _, rootPath := range rootPaths {
+		node, err := w.buildFSNode(nil, ".", rootPath)
+		if err != nil {
+			return err
+		}
+		if err := w.walkNode(node, preVisit, postVisit); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (w *Walker) createVirtualTree(paths []string, preVisit VisitFunc, postVisit VisitFunc) error {
+	root := &Node{
+		Type: DirectoryNode,
+		Path: "/",
+	}
+	w.nodeMap["/"] = root
+
+	for _, path := range paths {
+		if err := w.addVirtualNode(root, path); err != nil {
+			return err
+		}
+	}
+
+	return w.walkNode(root, preVisit, postVisit)
+}
+
+func (w *Walker) addVirtualNode(root *Node, path string) error {
+	parts := strings.Split(filepath.Clean(path), string(filepath.Separator))
+	current := root
+
+	for i, part := range parts {
+		if part == "" {
+			continue
+		}
+
+		childPath := "/" + filepath.Join(parts[:i+1]...)
+		child, exists := w.nodeMap[childPath]
+
+		if !exists {
+			isDir := i < len(parts)-1
+			nodeType := DirectoryNode
+			if !isDir {
+				nodeType = FileNode
+			}
+			child = &Node{
+				Type:   nodeType,
+				Path:   childPath,
+				Parent: current,
+			}
+			current.Children = append(current.Children, child)
+			w.nodeMap[childPath] = child
+		}
+
+		current = child
+	}
+
+	return nil
+}
+
+func (w *Walker) buildFSNode(parent *Node, basePath string, path string) (*Node, error) {
+	fileInfo, err := fs.Stat(w.fs, path)
+	if err != nil {
+		return nil, err
+	}
+
+	node := &Node{
+		Type:   determineNodeType(fileInfo.IsDir()),
+		Path:   path,
+		Parent: parent,
+	}
+
+	w.nodeMap[path] = node
+
+	if fileInfo.IsDir() {
+		entries, err := fs.ReadDir(w.fs, path)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			childPath := filepath.Join(path, entry.Name())
+			info, err := entry.Info()
+			if err != nil {
+				return nil, err
+			}
+			if !w.FollowSymlinks && isSymlink(info) {
+				continue
+			}
+			childNode, err := w.buildFSNode(node, basePath, childPath)
+			if err != nil {
+				return nil, err
+			}
+			node.Children = append(node.Children, childNode)
+		}
+	}
+	return node, nil
+}
+
+func (w *Walker) walkNode(node *Node, preVisit VisitFunc, postVisit VisitFunc) error {
+	if preVisit != nil {
+		if err := preVisit(w, node); err != nil {
+			return err
+		}
+	}
+
+	for _, child := range node.Children {
+		if err := w.walkNode(child, preVisit, postVisit); err != nil {
+			return err
+		}
+	}
+
+	if postVisit != nil {
+		if err := postVisit(w, node); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func determineNodeType(isDir bool) NodeType {
+	if isDir {
+		return DirectoryNode
+	}
+	return FileNode
+}
+
+func isSymlink(fileInfo os.FileInfo) bool {
+	return fileInfo.Mode()&os.ModeSymlink != 0
+}
+
+// GetNodeByPath retrieves a node by its path.
+func (w *Walker) GetNodeByPath(path string) (*Node, error) {
+	node, ok := w.nodeMap[path]
+	if !ok {
+		return nil, fmt.Errorf("node not found for path: %s", path)
+	}
+	return node, nil
+}
+
+// GetNodeByRelativePath retrieves a node by a path relative to a base node.
+func (w *Walker) GetNodeByRelativePath(baseNode *Node, relativePath string) (*Node, error) {
+	fullPath := filepath.Join(baseNode.Path, relativePath)
+	return w.GetNodeByPath(fullPath)
+}

--- a/pkg/filewalker/walker.go
+++ b/pkg/filewalker/walker.go
@@ -139,11 +139,7 @@ func (w *Walker) Walk(paths []string, preVisit VisitFunc, postVisit VisitFunc) e
 func (w *Walker) walkFS(rootPaths []string, preVisit VisitFunc, postVisit VisitFunc) error {
 	for _, rootPath := range rootPaths {
 		absPath := w.resolveRelativePath(rootPath)
-		relPath, err := filepath.Rel("/", absPath)
-		if err != nil {
-			return fmt.Errorf("failed to get relative path: %w", err)
-		}
-		node, err := w.buildFSNode(nil, "/", relPath)
+		node, err := w.buildFSNode(nil, absPath)
 		if err != nil {
 			return err
 		}
@@ -206,7 +202,7 @@ func (w *Walker) addVirtualNode(root *Node, path string) error {
 	return nil
 }
 
-func (w *Walker) buildFSNode(parent *Node, basePath string, path string) (*Node, error) {
+func (w *Walker) buildFSNode(parent *Node, path string) (*Node, error) {
 	absPath := filepath.Join("/", path)
 	fileInfo, err := fs.Stat(w.fs, path)
 	if err != nil {
@@ -242,7 +238,7 @@ func (w *Walker) buildFSNode(parent *Node, basePath string, path string) (*Node,
 			if !w.FollowSymlinks && isSymlink(info) {
 				continue
 			}
-			childNode, err := w.buildFSNode(node, basePath, childPath)
+			childNode, err := w.buildFSNode(node, childPath)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/filewalker/walker_test.go
+++ b/pkg/filewalker/walker_test.go
@@ -68,359 +68,44 @@ func TestWalker_Walk(t *testing.T) {
 	}
 }
 
-func TestWalker_GetNodeByPath(t *testing.T) {
-	_, w, cleanup := setupTestEnvironment(t)
-	defer cleanup()
+func TestWalker_ResolveRelativePath(t *testing.T) {
+	currentDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current working directory: %v", err)
+	}
+
+	w := &Walker{currentDir: currentDir}
 
 	tests := []struct {
-		name          string
-		path          string
-		expectedType  NodeType
-		expectedError bool
+		name     string
+		input    string
+		expected string
 	}{
 		{
-			name:          "Get existing file",
-			path:          "file1.txt",
-			expectedType:  FileNode,
-			expectedError: false,
+			name:     "Absolute path",
+			input:    "/absolute/path",
+			expected: "/absolute/path",
 		},
 		{
-			name:          "Get existing directory",
-			path:          "subdir1",
-			expectedType:  DirectoryNode,
-			expectedError: false,
+			name:     "Relative path",
+			input:    "relative/path",
+			expected: filepath.Join(currentDir, "relative/path"),
 		},
 		{
-			name:          "Get non-existent file",
-			path:          "nonexistent.txt",
-			expectedType:  FileNode,
-			expectedError: true,
+			name:     "Current directory",
+			input:    ".",
+			expected: currentDir,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			node, err := w.GetNodeByPath(tt.path)
-
-			if tt.expectedError {
-				if err == nil {
-					t.Errorf("Expected an error, but got nil")
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				if node.Type != tt.expectedType {
-					t.Errorf("Expected node type %v, but got %v", tt.expectedType, node.Type)
-				}
-				if node.Path != tt.path {
-					t.Errorf("Expected path %s, but got %s", tt.path, node.Path)
-				}
+			result := w.resolveRelativePath(tt.input)
+			if result != tt.expected {
+				t.Errorf("Expected %s, got %s", tt.expected, result)
 			}
 		})
 	}
 }
 
-func TestWalker_GetNodeByRelativePath(t *testing.T) {
-	_, w, cleanup := setupTestEnvironment(t)
-	defer cleanup()
-
-	// Get the root node
-	rootNode, err := w.GetNodeByPath(".")
-	if err != nil {
-		t.Fatalf("Failed to get root node: %v", err)
-	}
-
-	tests := []struct {
-		name          string
-		relativePath  string
-		expectedType  NodeType
-		expectedError bool
-	}{
-		{
-			name:          "Get existing file",
-			relativePath:  "file1.txt",
-			expectedType:  FileNode,
-			expectedError: false,
-		},
-		{
-			name:          "Get existing directory",
-			relativePath:  "subdir1",
-			expectedType:  DirectoryNode,
-			expectedError: false,
-		},
-		{
-			name:          "Get file in subdirectory",
-			relativePath:  filepath.Join("subdir1", "file3.txt"),
-			expectedType:  FileNode,
-			expectedError: false,
-		},
-		{
-			name:          "Get non-existent file",
-			relativePath:  "nonexistent.txt",
-			expectedType:  FileNode,
-			expectedError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			node, err := w.GetNodeByRelativePath(rootNode, tt.relativePath)
-
-			if tt.expectedError {
-				if err == nil {
-					t.Errorf("Expected an error, but got nil")
-				}
-			} else {
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				if node.Type != tt.expectedType {
-					t.Errorf("Expected node type %v, but got %v", tt.expectedType, node.Type)
-				}
-				expectedPath := filepath.Join(".", tt.relativePath)
-				if node.Path != expectedPath {
-					t.Errorf("Expected path %s, but got %s", expectedPath, node.Path)
-				}
-			}
-		})
-	}
-}
-
-// Helper function to set up the test environment
-func setupTestEnvironment(t *testing.T) (fstest.MapFS, *Walker, func()) {
-	testFS := fstest.MapFS{
-		"file1.txt":                 &fstest.MapFile{},
-		"file2.txt":                 &fstest.MapFile{},
-		"subdir1/file3.txt":         &fstest.MapFile{},
-		"subdir1/subdir2/file4.txt": &fstest.MapFile{},
-	}
-
-	w, err := NewWalker(WithFS(testFS))
-	if err != nil {
-		t.Fatalf("Failed to create Walker: %v", err)
-	}
-	err = w.Walk([]string{"."}, nil, nil)
-	if err != nil {
-		t.Fatalf("Failed to walk directory: %v", err)
-	}
-
-	cleanup := func() {
-		// No cleanup needed for in-memory file system
-	}
-
-	return testFS, w, cleanup
-}
-
-func TestWalker_FollowSymlinks(t *testing.T) {
-	tempDir, cleanup := setupSymlinkTestEnvironment(t)
-	defer cleanup()
-
-	tests := []struct {
-		name           string
-		followSymlinks bool
-		expectedFiles  int
-		expectedDirs   int
-	}{
-		{
-			name:           "Follow symlinks",
-			followSymlinks: true,
-			expectedFiles:  7, // 4 regular files + 1 symlinked file + 1 symlinked dir
-			expectedDirs:   5, // root, subdir1, subdir1/subdir2, symlinked_dir
-		},
-		{
-			name:           "Don't follow symlinks",
-			followSymlinks: false,
-			expectedFiles:  4, // 4 regular files
-			expectedDirs:   3, // root, subdir1, subdir1/subdir2
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			w, err := NewWalker(WithFS(os.DirFS(tempDir)), WithFollowSymlinks(tt.followSymlinks))
-			if err != nil {
-				t.Fatalf("Failed to create Walker: %v", err)
-			}
-			var filesCount, dirsCount int
-			var filesList, dirsList []string
-
-			err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
-				if node.Type == FileNode {
-					filesCount++
-					filesList = append(filesList, node.Path)
-				} else {
-					dirsCount++
-					dirsList = append(dirsList, node.Path)
-				}
-				return nil
-			}, nil)
-
-			if err != nil {
-				t.Fatalf("Walk failed: %v", err)
-			}
-
-			if filesCount != tt.expectedFiles {
-				t.Errorf("Expected %d files, got %d", tt.expectedFiles, filesCount)
-			}
-
-			if dirsCount != tt.expectedDirs {
-				t.Errorf("Expected %d directories, got %d", tt.expectedDirs, dirsCount)
-			}
-
-			//t.Logf("Files found: %v", filesList)
-			//t.Logf("Directories found: %v", dirsList)
-		})
-	}
-}
-
-// Helper function to set up a test environment with symlinks
-func setupSymlinkTestEnvironment(t *testing.T) (string, func()) {
-	tempDir, err := os.MkdirTemp("", "filewalker_symlink_test")
-	if err != nil {
-		t.Fatalf("Failed to create temp directory: %v", err)
-	}
-
-	testFiles := map[string]string{
-		"file1.txt":                 "content1",
-		"file2.txt":                 "content2",
-		"subdir1/file3.txt":         "content3",
-		"subdir1/subdir2/file4.txt": "content4",
-	}
-
-	for path, content := range testFiles {
-		fullPath := filepath.Join(tempDir, path)
-		dir := filepath.Dir(fullPath)
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory %s: %v", dir, err)
-		}
-		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
-			t.Fatalf("Failed to create file %s: %v", fullPath, err)
-		}
-	}
-
-	// Create a symlink to a file
-	if err := os.Symlink(filepath.Join(tempDir, "file1.txt"), filepath.Join(tempDir, "symlink_file.txt")); err != nil {
-		t.Fatalf("Failed to create symlink: %v", err)
-	}
-
-	// Create a symlink to a directory
-	if err := os.Symlink(filepath.Join(tempDir, "subdir1"), filepath.Join(tempDir, "symlink_dir")); err != nil {
-		t.Fatalf("Failed to create symlink: %v", err)
-	}
-
-	cleanup := func() {
-		_ = os.RemoveAll(tempDir)
-	}
-
-	return tempDir, cleanup
-}
-
-func TestWalker_MultipleRootPaths(t *testing.T) {
-	paths := []string{
-		"file1.txt",
-		"file2.txt",
-		"subdir1/file3.txt",
-		"subdir1/subdir2/file4.txt",
-	}
-
-	w, err := NewWalker(WithPaths(paths))
-	if err != nil {
-		t.Fatalf("Failed to create Walker: %v", err)
-	}
-
-	var visitedPaths []string
-
-	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
-		if node.Type == FileNode {
-			visitedPaths = append(visitedPaths, node.Path)
-		}
-		return nil
-	}, nil)
-
-	if err != nil {
-		t.Fatalf("Walk failed: %v", err)
-	}
-
-	expectedPaths := paths
-
-	if len(visitedPaths) != len(expectedPaths) {
-		t.Errorf("Expected %d paths, got %d", len(expectedPaths), len(visitedPaths))
-	}
-
-	for _, expected := range expectedPaths {
-		found := false
-		for _, visited := range visitedPaths {
-			if visited == expected {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("Expected path %s not found in visited paths", expected)
-		}
-	}
-}
-
-func TestWalker_PrePostVisitFunctions(t *testing.T) {
-	_, w, cleanup := setupTestEnvironment(t)
-	defer cleanup()
-
-	var preVisitOrder, postVisitOrder []string
-
-	preVisit := func(w *Walker, node *Node) error {
-		preVisitOrder = append(preVisitOrder, node.Path)
-		return nil
-	}
-
-	postVisit := func(w *Walker, node *Node) error {
-		postVisitOrder = append(postVisitOrder, node.Path)
-		return nil
-	}
-
-	err := w.Walk([]string{"."}, preVisit, postVisit)
-	if err != nil {
-		t.Fatalf("Walk failed: %v", err)
-	}
-
-	expectedPreOrder := []string{
-		".",
-		"file1.txt",
-		"file2.txt",
-		"subdir1",
-		"subdir1/file3.txt",
-		"subdir1/subdir2",
-		"subdir1/subdir2/file4.txt",
-	}
-
-	expectedPostOrder := []string{
-		"file1.txt",
-		"file2.txt",
-		"subdir1/file3.txt",
-		"subdir1/subdir2/file4.txt",
-		"subdir1/subdir2",
-		"subdir1",
-		".",
-	}
-
-	if !stringSlicesEqual(preVisitOrder, expectedPreOrder) {
-		t.Errorf("Pre-visit order incorrect.\nExpected: %v\nGot: %v", expectedPreOrder, preVisitOrder)
-	}
-
-	if !stringSlicesEqual(postVisitOrder, expectedPostOrder) {
-		t.Errorf("Post-visit order incorrect.\nExpected: %v\nGot: %v", expectedPostOrder, postVisitOrder)
-	}
-}
-
-// Helper function to compare string slices
-func stringSlicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
+// Add more tests for other methods as needed...

--- a/pkg/filewalker/walker_test.go
+++ b/pkg/filewalker/walker_test.go
@@ -1,0 +1,426 @@
+package filewalker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+)
+
+func TestWalker_Walk(t *testing.T) {
+	// Create an in-memory file system for testing
+	testFS := fstest.MapFS{
+		"file1.txt":                 &fstest.MapFile{},
+		"file2.txt":                 &fstest.MapFile{},
+		"subdir1/file3.txt":         &fstest.MapFile{},
+		"subdir1/subdir2/file4.txt": &fstest.MapFile{},
+	}
+
+	tests := []struct {
+		name          string
+		rootPath      string
+		expectedFiles int
+		expectedDirs  int
+	}{
+		{
+			name:          "Walk entire directory",
+			rootPath:      ".",
+			expectedFiles: 4,
+			expectedDirs:  3, // root, subdir1, subdir1/subdir2
+		},
+		{
+			name:          "Walk subdirectory",
+			rootPath:      "subdir1",
+			expectedFiles: 2,
+			expectedDirs:  2, // subdir1, subdir1/subdir2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWalker(WithFS(testFS))
+			if err != nil {
+				t.Fatalf("Failed to create Walker: %v", err)
+			}
+			var filesCount, dirsCount int
+
+			err = w.Walk([]string{tt.rootPath}, func(w *Walker, node *Node) error {
+				if node.Type == FileNode {
+					filesCount++
+				} else {
+					dirsCount++
+				}
+				return nil
+			}, nil)
+
+			if err != nil {
+				t.Fatalf("Walk failed: %v", err)
+			}
+
+			if filesCount != tt.expectedFiles {
+				t.Errorf("Expected %d files, got %d", tt.expectedFiles, filesCount)
+			}
+
+			if dirsCount != tt.expectedDirs {
+				t.Errorf("Expected %d directories, got %d", tt.expectedDirs, dirsCount)
+			}
+		})
+	}
+}
+
+func TestWalker_GetNodeByPath(t *testing.T) {
+	_, w, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	tests := []struct {
+		name          string
+		path          string
+		expectedType  NodeType
+		expectedError bool
+	}{
+		{
+			name:          "Get existing file",
+			path:          "file1.txt",
+			expectedType:  FileNode,
+			expectedError: false,
+		},
+		{
+			name:          "Get existing directory",
+			path:          "subdir1",
+			expectedType:  DirectoryNode,
+			expectedError: false,
+		},
+		{
+			name:          "Get non-existent file",
+			path:          "nonexistent.txt",
+			expectedType:  FileNode,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := w.GetNodeByPath(tt.path)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected an error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if node.Type != tt.expectedType {
+					t.Errorf("Expected node type %v, but got %v", tt.expectedType, node.Type)
+				}
+				if node.Path != tt.path {
+					t.Errorf("Expected path %s, but got %s", tt.path, node.Path)
+				}
+			}
+		})
+	}
+}
+
+func TestWalker_GetNodeByRelativePath(t *testing.T) {
+	_, w, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	// Get the root node
+	rootNode, err := w.GetNodeByPath(".")
+	if err != nil {
+		t.Fatalf("Failed to get root node: %v", err)
+	}
+
+	tests := []struct {
+		name          string
+		relativePath  string
+		expectedType  NodeType
+		expectedError bool
+	}{
+		{
+			name:          "Get existing file",
+			relativePath:  "file1.txt",
+			expectedType:  FileNode,
+			expectedError: false,
+		},
+		{
+			name:          "Get existing directory",
+			relativePath:  "subdir1",
+			expectedType:  DirectoryNode,
+			expectedError: false,
+		},
+		{
+			name:          "Get file in subdirectory",
+			relativePath:  filepath.Join("subdir1", "file3.txt"),
+			expectedType:  FileNode,
+			expectedError: false,
+		},
+		{
+			name:          "Get non-existent file",
+			relativePath:  "nonexistent.txt",
+			expectedType:  FileNode,
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node, err := w.GetNodeByRelativePath(rootNode, tt.relativePath)
+
+			if tt.expectedError {
+				if err == nil {
+					t.Errorf("Expected an error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if node.Type != tt.expectedType {
+					t.Errorf("Expected node type %v, but got %v", tt.expectedType, node.Type)
+				}
+				expectedPath := filepath.Join(".", tt.relativePath)
+				if node.Path != expectedPath {
+					t.Errorf("Expected path %s, but got %s", expectedPath, node.Path)
+				}
+			}
+		})
+	}
+}
+
+// Helper function to set up the test environment
+func setupTestEnvironment(t *testing.T) (fstest.MapFS, *Walker, func()) {
+	testFS := fstest.MapFS{
+		"file1.txt":                 &fstest.MapFile{},
+		"file2.txt":                 &fstest.MapFile{},
+		"subdir1/file3.txt":         &fstest.MapFile{},
+		"subdir1/subdir2/file4.txt": &fstest.MapFile{},
+	}
+
+	w, err := NewWalker(WithFS(testFS))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+	err = w.Walk([]string{"."}, nil, nil)
+	if err != nil {
+		t.Fatalf("Failed to walk directory: %v", err)
+	}
+
+	cleanup := func() {
+		// No cleanup needed for in-memory file system
+	}
+
+	return testFS, w, cleanup
+}
+
+func TestWalker_FollowSymlinks(t *testing.T) {
+	tempDir, cleanup := setupSymlinkTestEnvironment(t)
+	defer cleanup()
+
+	tests := []struct {
+		name           string
+		followSymlinks bool
+		expectedFiles  int
+		expectedDirs   int
+	}{
+		{
+			name:           "Follow symlinks",
+			followSymlinks: true,
+			expectedFiles:  7, // 4 regular files + 1 symlinked file + 1 symlinked dir
+			expectedDirs:   5, // root, subdir1, subdir1/subdir2, symlinked_dir
+		},
+		{
+			name:           "Don't follow symlinks",
+			followSymlinks: false,
+			expectedFiles:  4, // 4 regular files
+			expectedDirs:   3, // root, subdir1, subdir1/subdir2
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWalker(WithFS(os.DirFS(tempDir)), WithFollowSymlinks(tt.followSymlinks))
+			if err != nil {
+				t.Fatalf("Failed to create Walker: %v", err)
+			}
+			var filesCount, dirsCount int
+			var filesList, dirsList []string
+
+			err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+				if node.Type == FileNode {
+					filesCount++
+					filesList = append(filesList, node.Path)
+				} else {
+					dirsCount++
+					dirsList = append(dirsList, node.Path)
+				}
+				return nil
+			}, nil)
+
+			if err != nil {
+				t.Fatalf("Walk failed: %v", err)
+			}
+
+			if filesCount != tt.expectedFiles {
+				t.Errorf("Expected %d files, got %d", tt.expectedFiles, filesCount)
+			}
+
+			if dirsCount != tt.expectedDirs {
+				t.Errorf("Expected %d directories, got %d", tt.expectedDirs, dirsCount)
+			}
+
+			//t.Logf("Files found: %v", filesList)
+			//t.Logf("Directories found: %v", dirsList)
+		})
+	}
+}
+
+// Helper function to set up a test environment with symlinks
+func setupSymlinkTestEnvironment(t *testing.T) (string, func()) {
+	tempDir, err := os.MkdirTemp("", "filewalker_symlink_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp directory: %v", err)
+	}
+
+	testFiles := map[string]string{
+		"file1.txt":                 "content1",
+		"file2.txt":                 "content2",
+		"subdir1/file3.txt":         "content3",
+		"subdir1/subdir2/file4.txt": "content4",
+	}
+
+	for path, content := range testFiles {
+		fullPath := filepath.Join(tempDir, path)
+		dir := filepath.Dir(fullPath)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory %s: %v", dir, err)
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			t.Fatalf("Failed to create file %s: %v", fullPath, err)
+		}
+	}
+
+	// Create a symlink to a file
+	if err := os.Symlink(filepath.Join(tempDir, "file1.txt"), filepath.Join(tempDir, "symlink_file.txt")); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	// Create a symlink to a directory
+	if err := os.Symlink(filepath.Join(tempDir, "subdir1"), filepath.Join(tempDir, "symlink_dir")); err != nil {
+		t.Fatalf("Failed to create symlink: %v", err)
+	}
+
+	cleanup := func() {
+		_ = os.RemoveAll(tempDir)
+	}
+
+	return tempDir, cleanup
+}
+
+func TestWalker_MultipleRootPaths(t *testing.T) {
+	paths := []string{
+		"file1.txt",
+		"file2.txt",
+		"subdir1/file3.txt",
+		"subdir1/subdir2/file4.txt",
+	}
+
+	w, err := NewWalker(WithPaths(paths))
+	if err != nil {
+		t.Fatalf("Failed to create Walker: %v", err)
+	}
+
+	var visitedPaths []string
+
+	err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+		if node.Type == FileNode {
+			visitedPaths = append(visitedPaths, node.Path)
+		}
+		return nil
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	expectedPaths := paths
+
+	if len(visitedPaths) != len(expectedPaths) {
+		t.Errorf("Expected %d paths, got %d", len(expectedPaths), len(visitedPaths))
+	}
+
+	for _, expected := range expectedPaths {
+		found := false
+		for _, visited := range visitedPaths {
+			if visited == expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected path %s not found in visited paths", expected)
+		}
+	}
+}
+
+func TestWalker_PrePostVisitFunctions(t *testing.T) {
+	_, w, cleanup := setupTestEnvironment(t)
+	defer cleanup()
+
+	var preVisitOrder, postVisitOrder []string
+
+	preVisit := func(w *Walker, node *Node) error {
+		preVisitOrder = append(preVisitOrder, node.Path)
+		return nil
+	}
+
+	postVisit := func(w *Walker, node *Node) error {
+		postVisitOrder = append(postVisitOrder, node.Path)
+		return nil
+	}
+
+	err := w.Walk([]string{"."}, preVisit, postVisit)
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+
+	expectedPreOrder := []string{
+		".",
+		"file1.txt",
+		"file2.txt",
+		"subdir1",
+		"subdir1/file3.txt",
+		"subdir1/subdir2",
+		"subdir1/subdir2/file4.txt",
+	}
+
+	expectedPostOrder := []string{
+		"file1.txt",
+		"file2.txt",
+		"subdir1/file3.txt",
+		"subdir1/subdir2/file4.txt",
+		"subdir1/subdir2",
+		"subdir1",
+		".",
+	}
+
+	if !stringSlicesEqual(preVisitOrder, expectedPreOrder) {
+		t.Errorf("Pre-visit order incorrect.\nExpected: %v\nGot: %v", expectedPreOrder, preVisitOrder)
+	}
+
+	if !stringSlicesEqual(postVisitOrder, expectedPostOrder) {
+		t.Errorf("Post-visit order incorrect.\nExpected: %v\nGot: %v", expectedPostOrder, postVisitOrder)
+	}
+}
+
+// Helper function to compare string slices
+func stringSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/filewalker/walker_test.go
+++ b/pkg/filewalker/walker_test.go
@@ -3,6 +3,7 @@ package filewalker
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 )
@@ -103,6 +104,77 @@ func TestWalker_ResolveRelativePath(t *testing.T) {
 			result := w.resolveRelativePath(tt.input)
 			if result != tt.expected {
 				t.Errorf("Expected %s, got %s", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestWalker_WithFilter(t *testing.T) {
+	testFS := fstest.MapFS{
+		"file1.txt":                 &fstest.MapFile{},
+		"file2.txt":                 &fstest.MapFile{},
+		"subdir1/file3.txt":         &fstest.MapFile{},
+		"subdir1/subdir2/file4.txt": &fstest.MapFile{},
+		"subdir3/file5.txt":         &fstest.MapFile{},
+	}
+
+	tests := []struct {
+		name          string
+		filter        func(node *Node) bool
+		expectedFiles int
+		expectedDirs  int
+	}{
+		{
+			name:          "No filter",
+			filter:        nil,
+			expectedFiles: 5,
+			expectedDirs:  4, // root, subdir1, subdir1/subdir2, subdir3
+		},
+		{
+			name: "Filter out subdir1",
+			filter: func(node *Node) bool {
+				return !strings.HasPrefix(node.Path, "/subdir1")
+			},
+			expectedFiles: 3,
+			expectedDirs:  2, // root, subdir3
+		},
+		{
+			name: "Only .txt files and directories",
+			filter: func(node *Node) bool {
+				return node.Type == DirectoryNode || strings.HasSuffix(node.Path, ".txt")
+			},
+			expectedFiles: 5,
+			expectedDirs:  4, // root, subdir1, subdir1/subdir2, subdir3
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w, err := NewWalker(WithFS(testFS), WithFilter(tt.filter))
+			if err != nil {
+				t.Fatalf("Failed to create Walker: %v", err)
+			}
+			var filesCount, dirsCount int
+
+			err = w.Walk([]string{"."}, func(w *Walker, node *Node) error {
+				if node.Type == FileNode {
+					filesCount++
+				} else {
+					dirsCount++
+				}
+				return nil
+			}, nil)
+
+			if err != nil {
+				t.Fatalf("Walk failed: %v", err)
+			}
+
+			if filesCount != tt.expectedFiles {
+				t.Errorf("Expected %d files, got %d", tt.expectedFiles, filesCount)
+			}
+
+			if dirsCount != tt.expectedDirs {
+				t.Errorf("Expected %d directories, got %d", tt.expectedDirs, dirsCount)
 			}
 		})
 	}


### PR DESCRIPTION
This PR introduces two new packages: filewalker and filefilter.
Filewalker: - Implements an AST-like structure for filesystem traversal - Supports custom file systems (fs.FS) and virtual file trees - Provides pre-visit and post-visit callbacks - Includes options for following symlinks and filtering nodes
Filefilter: - Offers configurable file filtering based on various criteria - Supports file size limits, extension filtering, and pattern matching - Includes gitignore integration and binary file detection - Provides YAML serialization for easy configuration management
Additional changes: - Add comprehensive test suites for both packages - Update repository.go to handle non-existent doc directories
These packages enhance file system traversal and filtering capabilities, useful for various file processing tasks within the project.