### PR TITLE
Fix bugs in repository and file watchers

### DIFF
--- a/pkg/repositories/watcher.go
+++ b/pkg/repositories/watcher.go
@@ -106,7 +106,16 @@ func (r *Repository) Watch(
 			}
 
 			// XXX we would actually need to map the command name to the file name because at this point we assume that the command name is the file base name.
+			fs_, filePath, err := loaders.FileNameToFsFilePath(path)
+			if err != nil {
+				return errors.Wrapf(err, "could not get fs and file path for %s", path)
+			}
 			parents = append(parents, strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))
+			supported := r.loader.IsFileSupported(fs_, filePath)
+			if !supported {
+				log.Debug().Msgf("File %s is not supported, skipping removal", path)
+				return nil
+			}
 			r.Remove(parents)
 			return nil
 		}),

--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -302,6 +302,12 @@ func (w *Watcher) addRecursive(watcher *fsnotify.Watcher, path string) error {
 		return err
 	}
 
+	// Skip socket files
+	if info.Mode()&os.ModeSocket != 0 {
+		log.Debug().Str("path", path).Msg("Skipping socket file")
+		return nil
+	}
+
 	if info.IsDir() {
 		// Directory handling
 		dirPath := path
@@ -325,6 +331,11 @@ func (w *Watcher) addRecursive(watcher *fsnotify.Watcher, path string) error {
 				return nil
 			}
 			if subpath == dirPath {
+				return nil
+			}
+			// Skip socket files during directory walk
+			if info.Mode()&os.ModeSocket != 0 {
+				log.Debug().Str("path", subpath).Msg("Skipping socket file")
 				return nil
 			}
 			log.Trace().Str("path", subpath).Msg("Testing subpath to watcher")


### PR DESCRIPTION
This PR addresses two specific issues in our file watching system:

* Skip unsupported files when handling file removal events
  - Check if removed file is supported before triggering removal logic
  - Add proper error handling for file path resolution
  - Prevents unnecessary processing of files that aren't relevant

* Add socket file handling in directory watcher
  - Skip socket files during initial path addition
  - Skip socket files during recursive directory walks
  - Improves stability by avoiding attempts to watch special file types
  
Both changes include appropriate debug logging to help with troubleshooting.