### PR TITLE
Fix null dereference in filewalker

### DIFF
--- a/pkg/filewalker/walker.go
+++ b/pkg/filewalker/walker.go
@@ -149,9 +149,15 @@ func (w *Walker) walkFS(rootPaths []string, preVisit VisitFunc, postVisit VisitF
 		if err != nil {
 			return err
 		}
+
+		if node == nil {
+			continue
+		}
+
 		if w.filter != nil && !w.filter(node) {
 			continue
 		}
+
 		if err := w.walkNode(node, preVisit, postVisit); err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes the walker panicking when a filter is used and the root node is filtered out