### PR TITLE
Add Viper configuration documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ Clay provides essential utilities and helper packages that solve common developm
 
 ## Packages
 
+### ⚙️ Configuration (`pkg/init.go`)
+Provides convenient Viper configuration initialization for Go applications. Clay wraps Viper with opinionated defaults and integration with Cobra CLI and structured logging.
+
+Features:
+- Multi-path config file discovery (`~/.appname`, `/etc/appname`, XDG config)
+- Environment variable support with automatic prefix handling
+- Cobra flag binding integration
+- Automatic logger initialization from config
+- Support for both global and instance-based Viper usage
+
+```go
+// Initialize with Cobra integration
+err := pkg.InitViper("myapp", rootCmd)
+
+// Or initialize standalone
+err := pkg.InitViperWithAppName("myapp", "config.yaml")
+
+// Create separate Viper instance
+v, err := pkg.InitViperInstanceWithAppName("myapp", "")
+```
+
+Configuration file locations (in order of precedence):
+- Explicit config file path
+- `~/.appname/config.yaml`
+- `/etc/appname/config.yaml`
+- XDG config directory (`~/.config/appname/config.yaml`)
+
 ### 🔄 Autoreload (`pkg/autoreload`)
 A WebSocket-based solution for automatically reloading web pages. Perfect for development environments where you want instant feedback on changes.
 


### PR DESCRIPTION
- Document Clay's Viper wrapper functions and initialization patterns
- Include configuration file discovery paths and precedence
- Show examples of InitViper, InitViperWithAppName, and InitViperInstanceWithAppName
- Explain integration with Cobra CLI and automatic logging setup

[Description pulled together by ampcode, as I trace back through the layers of your packages to understand/debug what's going on in the gcal integration. Seems correct but you know your stuff better than I]