### PR TITLE
Add SQL connection string helper functions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/go-go-golems/clay
 
 go 1.24.2
 
+toolchain go1.24.4
+
 require (
 	github.com/blevesearch/bleve/v2 v2.5.0
 	github.com/bmatcuk/doublestar/v4 v4.8.1

--- a/pkg/sql/settings.go
+++ b/pkg/sql/settings.go
@@ -118,3 +118,37 @@ func NewConfigFromRawParsedLayers(parsedLayers *layers.ParsedLayers) (*DatabaseC
 
 	return config, nil
 }
+
+// GetConnectionStringFromParsedLayers extracts a connection string from parsed layers
+// This is useful for tools like River that need a connection string directly
+func GetConnectionStringFromParsedLayers(parsedLayers *layers.ParsedLayers) (string, error) {
+	config, err := NewConfigFromRawParsedLayers(parsedLayers)
+	if err != nil {
+		return "", err
+	}
+
+	return config.GetConnectionString()
+}
+
+// GetConnectionStringFromSqlConnectionLayer extracts a connection string from specific layer names
+func GetConnectionStringFromSqlConnectionLayer(
+	parsedLayers *layers.ParsedLayers,
+	sqlConnectionLayerName string,
+	dbtLayerName string,
+) (string, error) {
+	sqlConnectionLayer, ok := parsedLayers.Get(sqlConnectionLayerName)
+	if !ok {
+		return "", errors.New("No sql-connection layer found")
+	}
+	dbtLayer, ok := parsedLayers.Get(dbtLayerName)
+	if !ok {
+		return "", errors.New("No dbt layer found")
+	}
+
+	config, err := NewConfigFromParsedLayers(sqlConnectionLayer, dbtLayer)
+	if err != nil {
+		return "", err
+	}
+
+	return config.GetConnectionString()
+}


### PR DESCRIPTION
This PR adds helper functions to extract SQL connection strings from database
configurations, making it easier to integrate with external tools that require
direct connection strings.

## Changes

• Add `GetConnectionString()` method to `DatabaseConfig` for extracting
  connection strings from either DSN or dbt source configurations
• Add `GetConnectionStringFromParsedLayers()` helper function to extract
  connection strings directly from parsed configuration layers
• Add `GetConnectionStringFromSqlConnectionLayer()` for extracting connection
  strings from specific named layers
• Refactor `Connect()` method to use new connection string helper internally
• Reduce log verbosity by changing debug logs to trace level