### PR TITLE
Fix connection string handling in database configuration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-go-golems/clay
 
-go 1.24.2
+go 1.24
 
 toolchain go1.24.5
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/go-go-golems/clay
 
-go 1.24
+go 1.24.2
 
 toolchain go1.24.5
 


### PR DESCRIPTION
- Normalize database driver names based on input source type or DSN.
- Update connection string handling for different database types.
- Automatically append a connection timeout for PostgreSQL if missing.
- Enhance compatibility with DSN formats for PostgreSQL, MySQL, and SQLite.
- Ensure driver aliases are correctly mapped to their respective drivers.