### PR TITLE
Run Glazed CLI policy linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,3 +32,5 @@ jobs:
         with:
           version-file: .golangci-lint-version
           args: --timeout=5m ./pkg/...
+      - name: Run Glazed CLI policy linters
+        run: make glazed-lint

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all test build lint lintmax docker-lint golangci-lint-install gosec govulncheck goreleaser tag-major tag-minor tag-patch release bump-glazed install logcopter-generate logcopter-check
+.PHONY: all test build lint lintmax docker-lint golangci-lint-install glazed-lint-build glazed-lint gosec govulncheck goreleaser tag-major tag-minor tag-patch release bump-glazed install logcopter-generate logcopter-check
 
 all: test build
 
@@ -6,6 +6,10 @@ VERSION=v0.1.14
 
 GOLANGCI_LINT_VERSION ?= $(shell cat .golangci-lint-version)
 GOLANGCI_LINT_BIN ?= $(CURDIR)/.bin/golangci-lint
+GLAZED_LINT_BIN ?= /tmp/glazed-lint
+GLAZED_LINT_PKG ?= github.com/go-go-golems/glazed/cmd/tools/glazed-lint
+GLAZED_VERSION ?= $(shell GOWORK=off go list -m -f '{{.Version}}' github.com/go-go-golems/glazed 2>/dev/null)
+GLAZED_LINT_FLAGS ?= -glazedclilint.allow-paths=pkg/analysis/,pkg/cli/,pkg/cmds/fields/,pkg/cmds/logging/,pkg/cmds/sources/,pkg/help/,pkg/cmds/profiles/,pkg/cmds/commandmeta/edit.go
 
 CACHE_DIR := $(CURDIR)/.cache
 LINT_GOCACHE := $(CACHE_DIR)/go-build
@@ -22,13 +26,28 @@ golangci-lint-install:
 	mkdir -p $(dir $(GOLANGCI_LINT_BIN))
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(dir $(GOLANGCI_LINT_BIN)) $(GOLANGCI_LINT_VERSION)
 
-lint: golangci-lint-install
+glazed-lint-build:
+	@echo "Building glazed-lint from Glazed module..."
+	@if [ -n "$(GLAZED_VERSION)" ] && [ "$(GLAZED_VERSION)" != "(devel)" ]; then \
+		echo "Installing $(GLAZED_LINT_PKG)@$(GLAZED_VERSION)"; \
+		GOBIN=$(dir $(GLAZED_LINT_BIN)) GOWORK=off go install $(GLAZED_LINT_PKG)@$(GLAZED_VERSION); \
+	else \
+		echo "Installing $(GLAZED_LINT_PKG) from workspace/module"; \
+		GOBIN=$(dir $(GLAZED_LINT_BIN)) go install $(GLAZED_LINT_PKG); \
+	fi
+
+glazed-lint: glazed-lint-build
+	go vet -vettool=$(GLAZED_LINT_BIN) $(GLAZED_LINT_FLAGS) ./pkg/...
+
+lint: glazed-lint-build golangci-lint-install
 	mkdir -p $(LINT_GOCACHE) $(LINT_XDG_CACHE_HOME)
 	XDG_CACHE_HOME=$(LINT_XDG_CACHE_HOME) GOCACHE=$(LINT_GOCACHE) $(GOLANGCI_LINT_BIN) run -v ./...
+	go vet -vettool=$(GLAZED_LINT_BIN) $(GLAZED_LINT_FLAGS) ./pkg/...
 
-lintmax: golangci-lint-install
+lintmax: glazed-lint-build golangci-lint-install
 	mkdir -p $(LINT_GOCACHE) $(LINT_XDG_CACHE_HOME)
 	XDG_CACHE_HOME=$(LINT_XDG_CACHE_HOME) GOCACHE=$(LINT_GOCACHE) $(GOLANGCI_LINT_BIN) run -v --max-same-issues=100 ./...
+	go vet -vettool=$(GLAZED_LINT_BIN) $(GLAZED_LINT_FLAGS) ./pkg/...
 
 test:
 	go test ./...

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/go-go-golems/clay
 
 go 1.25.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/blevesearch/bleve/v2 v2.5.0


### PR DESCRIPTION
## Summary
- add a reusable Makefile target that installs and runs Glazed's glazed-lint vettool from the repository's Glazed module version
- wire the Glazed CLI policy analyzer into lint/lintmax so lefthook runs it
- add a GitHub Actions lint step that runs make glazed-lint

## Validation
- make glazed-lint
- make lintmax